### PR TITLE
Add daily package update automation with failure reporting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # Keep GitHub Actions up-to-date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "automated"
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -1,0 +1,221 @@
+name: Daily Package Updates
+
+on:
+  schedule:
+    # Run at 3:00 AM UTC every day
+    - cron: '0 3 * * *'
+  workflow_dispatch:  # Allow manual triggers
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+    outputs:
+      update_success: ${{ steps.update.outputs.success }}
+      update_output: ${{ steps.update.outputs.output }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        
+      - name: Install Nix
+        uses: cachix/install-nix-action@v20
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+      
+      - name: Update flake inputs
+        id: update
+        run: |
+          if nix flake update; then
+            echo "success=true" >> $GITHUB_OUTPUT
+            echo "output=Successfully updated flake inputs" >> $GITHUB_OUTPUT
+          else
+            echo "success=false" >> $GITHUB_OUTPUT
+            echo "output=Failed to update flake inputs: $?" >> $GITHUB_OUTPUT
+          fi
+      
+      - name: Validate flake
+        id: validate
+        if: steps.update.outputs.success == 'true'
+        run: |
+          # Check if the flake still evaluates after updates
+          nix flake show
+
+  test-updated-configs:
+    needs: update-dependencies
+    if: needs.update-dependencies.outputs.update_success == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      desktop_success: ${{ steps.test-desktop.outputs.success }}
+      server_success: ${{ steps.test-server.outputs.success }}
+      homemanager_success: ${{ steps.test-homemanager.outputs.success }}
+      failure_details: ${{ steps.collect-results.outputs.failure_details }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        
+      - name: Install Nix
+        uses: cachix/install-nix-action@v20
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+      
+      - name: Update flake inputs
+        run: |
+          nix flake update
+      
+      - name: Temporarily update hardware configurations for CI
+        run: |
+          # Replace real hardware configs with CI-compatible versions
+          sed -i 's/^{/# Modified for CI testing\n{/' modules/hosts/desktop/hardware-configuration.nix
+          sed -i 's/^  fileSystems."\/" =/  fileSystems."\/" = { device = "none"; fsType = "tmpfs"; }; # /' modules/hosts/desktop/hardware-configuration.nix
+          sed -i 's/^  fileSystems."\/boot" =/  fileSystems."\/boot" = { device = "none"; fsType = "tmpfs"; }; # /' modules/hosts/desktop/hardware-configuration.nix
+          sed -i 's/^  swapDevices =/  swapDevices = [ ]; # /' modules/hosts/desktop/hardware-configuration.nix
+          
+          sed -i 's/^{/# Modified for CI testing\n{/' modules/hosts/server/hardware-configuration.nix
+          sed -i 's/^  fileSystems."\/" =/  fileSystems."\/" = { device = "none"; fsType = "tmpfs"; }; # /' modules/hosts/server/hardware-configuration.nix
+          sed -i 's/^  fileSystems."\/boot" =/  fileSystems."\/boot" = { device = "none"; fsType = "tmpfs"; }; # /' modules/hosts/server/hardware-configuration.nix
+          sed -i 's/^  fileSystems."\/mnt\/media" =/  fileSystems."\/mnt\/media" = { device = "none"; fsType = "tmpfs"; options = [ "defaults" "nofail" ]; }; # /' modules/hosts/server/hardware-configuration.nix
+          sed -i 's/^  swapDevices =/  swapDevices = [ ]; # /' modules/hosts/server/hardware-configuration.nix
+      
+      - name: Test desktop configuration
+        id: test-desktop
+        run: |
+          # Test if desktop config still builds after updates
+          if nix build .#nixosConfigurations.desktop.config.system.build.toplevel --dry-run --allow-import-from-derivation; then
+            echo "success=true" >> $GITHUB_OUTPUT
+          else
+            echo "success=false" >> $GITHUB_OUTPUT
+            echo "::error::Desktop configuration build failed"
+          fi
+      
+      - name: Test server configuration
+        id: test-server
+        run: |
+          # Test if server config still builds after updates
+          if nix build .#nixosConfigurations.server.config.system.build.toplevel --dry-run --allow-import-from-derivation; then
+            echo "success=true" >> $GITHUB_OUTPUT
+          else
+            echo "success=false" >> $GITHUB_OUTPUT
+            echo "::error::Server configuration build failed"
+          fi
+      
+      - name: Test home-manager configuration
+        id: test-homemanager
+        run: |
+          # Test if home-manager config still builds
+          if nix build .#homeConfigurations.chromeos.activationPackage --dry-run --impure; then
+            echo "success=true" >> $GITHUB_OUTPUT
+          else
+            echo "success=false" >> $GITHUB_OUTPUT
+            echo "::error::Home Manager configuration build failed"
+          fi
+      
+      - name: Collect test results
+        id: collect-results
+        run: |
+          DETAILS=""
+          if [[ "${{ steps.test-desktop.outputs.success }}" == "false" ]]; then
+            DETAILS="${DETAILS}- Desktop configuration build failed\n"
+          fi
+          if [[ "${{ steps.test-server.outputs.success }}" == "false" ]]; then
+            DETAILS="${DETAILS}- Server configuration build failed\n"
+          fi
+          if [[ "${{ steps.test-homemanager.outputs.success }}" == "false" ]]; then
+            DETAILS="${DETAILS}- Home Manager configuration build failed\n"
+          fi
+          
+          echo "failure_details<<EOF" >> $GITHUB_OUTPUT
+          echo -e "$DETAILS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+  create-update-pr:
+    needs: test-updated-configs
+    if: |
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
+      needs.test-updated-configs.outputs.desktop_success == 'true' &&
+      needs.test-updated-configs.outputs.server_success == 'true' &&
+      needs.test-updated-configs.outputs.homemanager_success == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        
+      - name: Install Nix
+        uses: cachix/install-nix-action@v20
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+      
+      - name: Update flake inputs
+        run: |
+          nix flake update
+      
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: automated package updates"
+          title: "Automated Package Updates"
+          body: |
+            ## Automated Package Updates
+            
+            This PR updates all flake inputs to their latest versions.
+            
+            ### Changes
+            - Updated flake.lock with latest dependencies
+            - All tests passing with updated packages
+            
+            This PR was automatically generated by the daily update workflow.
+          branch: automated-updates
+          branch-suffix: timestamp
+          delete-branch: true
+          labels: |
+            automated
+            dependencies
+
+  create-issue-on-failure:
+    needs: [update-dependencies, test-updated-configs]
+    if: |
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
+      (needs.update-dependencies.outputs.update_success != 'true' ||
+       needs.test-updated-configs.outputs.desktop_success != 'true' ||
+       needs.test-updated-configs.outputs.server_success != 'true' ||
+       needs.test-updated-configs.outputs.homemanager_success != 'true')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        
+      - name: Determine failure reason
+        id: failure-reason
+        run: |
+          TITLE="Package Update Failure: "
+          BODY="The daily package update workflow failed on $(date).\n\n"
+          
+          if [[ "${{ needs.update-dependencies.outputs.update_success }}" != "true" ]]; then
+            TITLE="${TITLE}Failed to update flake"
+            BODY="${BODY}## Failure Details\n\nFailed to update flake inputs.\n\nError: ${{ needs.update-dependencies.outputs.update_output }}"
+          else
+            TITLE="${TITLE}Tests failed with updated packages"
+            BODY="${BODY}## Failure Details\n\nTests failed after updating packages.\n\n${{ needs.test-updated-configs.outputs.failure_details }}"
+          fi
+          
+          echo "title=$TITLE" >> $GITHUB_OUTPUT
+          echo "body<<EOF" >> $GITHUB_OUTPUT
+          echo -e "$BODY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+      
+      - name: Create Issue
+        uses: peter-evans/create-issue@v4
+        with:
+          title: ${{ steps.failure-reason.outputs.title }}
+          body: ${{ steps.failure-reason.outputs.body }}
+          labels: |
+            bug
+            dependencies

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A unified NixOS configuration system for desktops, servers, macOS, and ChromeOS.
 
 [![NixOS Configuration Test](https://github.com/patflynn/cosmo/actions/workflows/nixos-test.yml/badge.svg)](https://github.com/patflynn/cosmo/actions/workflows/nixos-test.yml)
 [![Nix Format Check](https://github.com/patflynn/cosmo/actions/workflows/nix-fmt.yml/badge.svg)](https://github.com/patflynn/cosmo/actions/workflows/nix-fmt.yml)
+[![Daily Package Updates](https://github.com/patflynn/cosmo/actions/workflows/daily-update.yml/badge.svg)](https://github.com/patflynn/cosmo/actions/workflows/daily-update.yml)
 
 ## Overview
 


### PR DESCRIPTION
## Summary

This PR adds automation to keep packages up-to-date and report on any failures:

### Automatic Package Updates
- Creates a daily workflow that updates all flake inputs at 3:00 AM UTC
- Tests all configurations with the updated packages
- Creates a PR with the updates when all tests pass

### Failure Reporting
- Creates GitHub issues when package updates fail
- Includes detailed error diagnostics in the issue
- Captures different failure modes (update failure vs. build failure)

### Additional Features
- Added Dependabot configuration to keep GitHub Actions up-to-date
- Added workflow status badge to README
- Supports manual triggering through workflow_dispatch

## Usage
- Updates happen automatically every day
- PRs with updates will be created when all tests pass
- Issues will be created when tests fail
- You can manually trigger updates using the Actions tab