### PR TITLE
Add WSL2 NixOS configuration support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ The repository is structured to support multiple platforms:
 1. **NixOS Linux** - Full system configuration for desktop and server
 2. **macOS** - Using nix-darwin for system configuration
 3. **ChromeOS** - Using standalone home-manager
+4. **WSL2** - NixOS running under Windows Subsystem for Linux
 
 ## Directory Structure
 
@@ -19,7 +20,8 @@ cosmo/
 │   ├── common/         # Shared NixOS configuration
 │   └── hosts/          # Host-specific configurations
 │       ├── desktop/    # Desktop configuration
-│       └── server/     # Server configuration
+│       ├── server/     # Server configuration
+│       └── wsl2/       # WSL2 configuration
 ├── home/               # Home-manager configurations
 │   ├── common/         # Shared home-manager config
 │   ├── linux/          # Linux-specific home config
@@ -33,6 +35,7 @@ cosmo/
 
 - **desktop**: Full NixOS configuration for desktop usage
 - **server**: Minimal NixOS configuration for server usage
+- **wsl2**: Optimized NixOS configuration for WSL2
 
 ### Home-Manager Configurations
 
@@ -51,6 +54,12 @@ sudo nixos-rebuild switch --flake github:patflynn/cosmo#desktop
 
 ```bash
 sudo nixos-rebuild switch --flake github:patflynn/cosmo#server
+```
+
+### WSL2
+
+```bash
+sudo nixos-rebuild switch --flake github:patflynn/cosmo#wsl2
 ```
 
 ### macOS

--- a/docs/wsl2-setup.md
+++ b/docs/wsl2-setup.md
@@ -1,0 +1,179 @@
+# NixOS on WSL2 Setup Guide
+
+This guide provides step-by-step instructions for setting up NixOS on Windows Subsystem for Linux 2 (WSL2).
+
+## Prerequisites
+
+1. Windows 10 version 2004 or higher / Windows 11
+2. WSL2 installed and enabled
+3. At least 8GB of RAM recommended
+4. At least 60GB of free disk space
+
+## Step 1: Install WSL2 on Windows
+
+If you haven't already installed WSL2, open PowerShell as Administrator and run:
+
+```powershell
+wsl --install
+```
+
+This will install Ubuntu as the default distribution. We'll replace this with NixOS.
+
+## Step 2: Download NixOS-WSL
+
+1. Download the latest NixOS-WSL tarball from the official repository:
+   https://github.com/nix-community/NixOS-WSL/releases
+
+2. Create a directory for NixOS:
+   ```powershell
+   mkdir C:\NixOS
+   ```
+
+3. Import the tarball into WSL:
+   ```powershell
+   wsl --import NixOS C:\NixOS path\to\nixos-wsl.tar.gz --version 2
+   ```
+
+## Step 3: Start NixOS
+
+Launch NixOS from PowerShell:
+
+```powershell
+wsl -d NixOS
+```
+
+You should now have a root shell in NixOS.
+
+## Step 4: Set Up User Account
+
+1. Create a new user (replace `username` with your desired username):
+   ```bash
+   nix-shell -p cryptsetup
+   useradd -m -G wheel -s /bin/sh username
+   passwd username
+   ```
+
+2. Edit the sudoers file to allow the wheel group to use sudo:
+   ```bash
+   visudo
+   ```
+   Uncomment the line: `%wheel ALL=(ALL) ALL`
+
+## Step 5: Clone and Configure Cosmo
+
+1. Install Git:
+   ```bash
+   nix-env -iA nixpkgs.git
+   ```
+
+2. Clone the repository (as your user, not root):
+   ```bash
+   su - username
+   mkdir -p ~/hack
+   cd ~/hack
+   git clone https://github.com/patflynn/cosmo.git
+   cd cosmo
+   ```
+
+3. Modify the username in the WSL2 configuration file if needed:
+   ```bash
+   # Edit modules/hosts/wsl2/default.nix to change the defaultUser
+   # from "patrick" to your username
+   ```
+
+## Step 6: Apply NixOS Configuration
+
+1. Build and switch to the new configuration:
+   ```bash
+   sudo nixos-rebuild switch --flake ~/hack/cosmo#wsl2
+   ```
+
+2. Reboot NixOS WSL (from PowerShell):
+   ```powershell
+   wsl --shutdown NixOS
+   wsl -d NixOS
+   ```
+
+## Step 7: Verify Installation
+
+1. Check NixOS version:
+   ```bash
+   nixos-version
+   ```
+
+2. Verify that home-manager configurations are applied:
+   ```bash
+   ls -la ~/.config
+   ```
+
+## Advanced Configuration
+
+### Graphics Support (X11)
+
+The default configuration disables X11 services since they're typically not needed in WSL. If you need GUI applications:
+
+1. Install an X server on Windows, such as [VcXsrv](https://sourceforge.net/projects/vcxsrv/).
+
+2. Enable X11 forwarding by modifying the WSL2 configuration:
+   ```nix
+   # In modules/hosts/wsl2/default.nix
+   services.xserver = {
+     enable = true;
+     displayManager.startx.enable = true;
+   };
+   ```
+
+3. Add to your .bashrc or .zshrc:
+   ```bash
+   export DISPLAY=$(grep -m 1 nameserver /etc/resolv.conf | awk '{print $2}'):0
+   ```
+
+### Windows Integration
+
+1. File system access:
+   - Windows drives are mounted at `/mnt/c`, `/mnt/d`, etc.
+   - Create symlinks to frequently used Windows locations:
+     ```bash
+     ln -sf /mnt/c/Users/YourWindowsUser/Documents ~/win-documents
+     ```
+
+2. Windows PATH integration:
+   - Already enabled in the configuration with `interop.appendWindowsPath = true;`
+   - You can call Windows executables like `notepad.exe`
+
+### Troubleshooting
+
+1. **Networking issues**: If you have connectivity problems:
+   ```bash
+   sudo ip addr show
+   sudo ip route show
+   ```
+
+2. **Memory/performance issues**: WSL2 by default may use too much memory. Create a `.wslconfig` file in your Windows user directory:
+   ```
+   [wsl2]
+   memory=4GB
+   processors=4
+   ```
+
+3. **File permission issues**: WSL and Windows handle permissions differently. Use:
+   ```bash
+   sudo chmod -R 755 /path/to/directory
+   ```
+
+## Updating NixOS
+
+Regular updates can be performed with:
+
+```bash
+sudo nixos-rebuild switch --flake ~/hack/cosmo#wsl2 --upgrade
+```
+
+## Uninstalling
+
+If you need to remove the NixOS WSL distribution:
+
+```powershell
+wsl --unregister NixOS
+rmdir C:\NixOS
+```

--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,21 @@
         ];
         specialArgs = inputs;
       };
+      
+      # WSL2 configuration
+      wsl2 = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [
+          ./modules/hosts/wsl2
+          home-manager.nixosModules.home-manager
+          {
+            home-manager.useGlobalPkgs = true;
+            home-manager.useUserPackages = true;
+            home-manager.users.patrick = import ./home/linux;
+          }
+        ];
+        specialArgs = inputs;
+      };
     };
     
     # Darwin configurations for macOS

--- a/modules/hosts/wsl2/default.nix
+++ b/modules/hosts/wsl2/default.nix
@@ -1,0 +1,56 @@
+# WSL2 NixOS host configuration
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [
+    ./hardware-configuration.nix
+    ../../common
+  ];
+
+  # WSL-specific settings
+  wsl = {
+    enable = true;
+    wslConf = {
+      automount.root = "/mnt";
+      interop.appendWindowsPath = true;
+      network.generateHosts = true;
+    };
+    defaultUser = "patrick";  # Replace with your username
+    startMenuLaunchers = true;
+  };
+
+  # Set hostname
+  networking.hostName = "nixos-wsl";
+
+  # WSL-specific packages
+  environment.systemPackages = with pkgs; [
+    wslu  # WSL utilities
+    dos2unix
+    ntfs3g
+  ];
+
+  # Set up GUI support
+  services.xserver = {
+    enable = false;  # No need for X11 server in WSL by default
+  };
+
+  # Allow unfree packages
+  nixpkgs.config.allowUnfree = true;
+
+  # Enable OpenSSH daemon
+  services.openssh.enable = true;
+
+  # Enable zsh
+  programs.zsh.enable = true;
+
+  # WSL-specific optimizations
+  # Reduces initial memory usage
+  boot.isContainer = true;
+  
+  # Networking is handled by Windows
+  networking.dhcpcd.enable = false;
+  
+  # Disable systemd services that don't work well in WSL
+  systemd.services.systemd-udevd.enable = false;
+  systemd.services.NetworkManager-wait-online.enable = false;
+}

--- a/modules/hosts/wsl2/hardware-configuration.nix
+++ b/modules/hosts/wsl2/hardware-configuration.nix
@@ -1,0 +1,27 @@
+# Mock hardware configuration for WSL2
+# Replace with your actual WSL2 hardware configuration when deploying
+{ config, lib, pkgs, modulesPath, ... }:
+
+{
+  imports = [ (modulesPath + "/installer/scan/not-detected.nix") ];
+
+  boot.initrd.availableKernelModules = [ ];
+  boot.initrd.kernelModules = [ ];
+  boot.kernelModules = [ ];
+  boot.extraModulePackages = [ ];
+
+  # WSL2 doesn't need traditional filesystem mounts
+  fileSystems."/" = {
+    device = "none";
+    fsType = "tmpfs";
+  };
+
+  # No swap needed for WSL2
+  swapDevices = [ ];
+
+  # Disable these for WSL2
+  boot.loader.grub.enable = false;
+  
+  # Basic networking
+  networking.useDHCP = lib.mkDefault true;
+}


### PR DESCRIPTION
## Summary
- Adds WSL2 host configuration with specific optimizations for running NixOS under Windows
- Integrates with existing home-manager configuration to provide a consistent environment
- Updates flake.nix to include the new WSL2 configuration
- Adds comprehensive documentation with step-by-step WSL2 setup guide

## Documentation
- Updated main README.md to include WSL2 in the supported platforms list
- Created detailed wsl2-setup.md with installation instructions and troubleshooting tips
- Added advanced configuration options for X11 support and Windows integration

## Test plan
- Test WSL2 configuration with `nixos-rebuild test --flake ~/hack/cosmo#wsl2`
- Verify WSL-specific optimizations work correctly
- Confirm home-manager integration provides expected user environment
- Test documentation steps on a fresh Windows installation
- Complete all validation tasks in issue #24

Resolves #24

🤖 Generated with [Claude Code](https://claude.ai/code)