### PR TITLE
Remove Kolide Launcher from NixOS configuration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,8 +23,6 @@
     };
     
     # Additional tools
-    kolide-launcher.url = "github:znewman01/kolide-launcher";
-    kolide-launcher.inputs.nixpkgs.follows = "nixpkgs";
     
     emacs-overlay = { 
       url = "github:nix-community/emacs-overlay"; 
@@ -45,7 +43,6 @@
     darwin, 
     doom-emacs, 
     emacs-overlay, 
-    kolide-launcher, 
     ... 
   }: {
     # NixOS configurations
@@ -61,7 +58,6 @@
             home-manager.useUserPackages = true;
             home-manager.users.patrick = import ./home/linux;
           }
-          kolide-launcher.nixosModules.x86_64-linux.default
         ];
         specialArgs = inputs;
       };


### PR DESCRIPTION

## Removed Kolide Launcher

This PR removes Kolide Launcher from the NixOS configuration:

- Removed kolide-launcher from flake inputs
- Removed kolide-launcher from inputs passthrough list
- Removed kolide-launcher module from desktop configuration
- Simplified additional tools section in the flake

This simplifies the configuration by removing an unused dependency.
