### PR TITLE
Improve daily update workflow with JasonEtco/create-an-issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/package-update-failure.md
+++ b/.github/ISSUE_TEMPLATE/package-update-failure.md
@@ -1,0 +1,9 @@
+---
+title: {{ title }}
+assignees: patflynn
+labels: bug, dependencies
+---
+
+{{ body }}
+
+This issue was created automatically by the daily update workflow on {{ date | date('YYYY-MM-DD') }}.

--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -212,10 +212,10 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
       
       - name: Create Issue
-        uses: peter-evans/create-issue@v5
-        with:
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           title: ${{ steps.failure-reason.outputs.title }}
           body: ${{ steps.failure-reason.outputs.body }}
-          labels: |
-            bug
-            dependencies
+        with:
+          filename: .github/ISSUE_TEMPLATE/package-update-failure.md


### PR DESCRIPTION

## Improved Daily Update Workflow

This PR improves the daily update workflow by using a more reliable and widely-used GitHub Action:

- Replaced peter-evans/create-issue with JasonEtco/create-an-issue@v2
- Added a dedicated issue template file for package update failures
- Updated workflow to use the template-based approach
- Added proper GITHUB_TOKEN assignment

The JasonEtco/create-an-issue action is more reliable and follows best practices by using templates with variables, which makes it more flexible and maintainable. This should fix the workflow failures related to issue creation.
