### PR TITLE
Remove Kolide Launcher from NixOS configuration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,8 +23,6 @@
     };
     
     # Additional tools
-    kolide-launcher.url = "github:znewman01/kolide-launcher";
-    kolide-launcher.inputs.nixpkgs.follows = "nixpkgs";
     
     # We'll re-enable these after the PR is fixed
     # emacs-overlay = { 
@@ -44,7 +42,6 @@
     flake-utils, 
     home-manager, 
     darwin, 
-    kolide-launcher, 
     ... 
   }: {
     # NixOS configurations
@@ -60,7 +57,6 @@
             home-manager.useUserPackages = true;
             home-manager.users.patrick = import ./home/linux;
           }
-          kolide-launcher.nixosModules.x86_64-linux.default
         ];
         specialArgs = inputs;
       };


### PR DESCRIPTION

## Removed Kolide Launcher

This PR removes Kolide Launcher from the NixOS configuration:

- Removed kolide-launcher from flake inputs
- Removed kolide-launcher from inputs passthrough list
- Removed kolide-launcher module from desktop configuration
- Simplified additional tools section in the flake

This simplifies the configuration by removing an unused dependency. After merging, you may also want to run  to update the flake.lock file and remove the Kolide references there, but the build should work fine regardless.
