### PR TITLE
Add flake.lock task to Roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,6 +30,7 @@ It defines the hardware, operating system, services, and user environments for t
 
 ### Phase 2: The Virtualization Host
 - [x] **Priority:** Setup CI (GitHub Actions) to verify builds on push/PR.
+- [ ] Generate and commit `flake.lock` (requires Nix machine).
 - [ ] Enable Virtualization (Libvirt/KVM) on `classic-laddie`.
 - [ ] Create a "Base Guest" module (shared config for all VMs).
 - [ ] Deploy first Dev VM (`dev-patrick`).


### PR DESCRIPTION
Adds a task to Phase 2 to generate and commit the flake.lock file, which is currently missing and requires a machine with Nix installed.