### PR TITLE
Add NixOS WSL2 VM to Roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,3 +42,4 @@ It defines the hardware, operating system, services, and user environments for t
 
 ### Phase 4: Expansion
 - [ ] Onboard other hardware (MacBooks, WSL) into the Flake.
+- [ ] Onboard NixOS VM (WSL2).


### PR DESCRIPTION
Adds the task of onboarding a NixOS VM under WSL2 to the Expansion phase of the roadmap.