### PR TITLE
Refactor Home Manager Configuration

### DIFF
--- a/home/core.nix
+++ b/home/core.nix
@@ -1,0 +1,48 @@
+{ config, pkgs, ... }:
+
+{
+  # Shell & Tools
+  home.packages = with pkgs; [
+    # Core Tools
+    ripgrep      # Fast grep (Essential for Doom Emacs)
+    fd           # Fast find (Essential for Doom Emacs)
+    jq           # JSON parser
+    tree         # Directory viewer
+    btop         # Fancy htop
+    
+    # Emacs (The Editor)
+    emacs        # The editor itself
+    
+    # Language Servers
+    nixd         # Nix LSP
+    python3
+    nodejs    
+  ];
+
+  programs.git = {
+    enable = true;
+    userName = "Patrick Flynn";
+    userEmail = "big.pat@gmail.com"; 
+    extraConfig = {
+      init.defaultBranch = "main";
+      pull.rebase = true;
+    };
+  };
+  
+  programs.zsh = {
+    enable = true;
+    enableCompletion = true;
+    autosuggestion.enable = true;
+    syntaxHighlighting.enable = true;
+    
+    shellAliases = {
+      ll = "ls -l";
+    };
+  };
+
+  programs.starship = {
+    enable = true;
+  };
+
+  home.stateVersion = "25.11";
+}

--- a/home/server.nix
+++ b/home/server.nix
@@ -1,52 +1,9 @@
 { config, pkgs, ... }:
 
 {
-  # Shell & Tools
-  home.packages = with pkgs; [
-    # Core Tools
-    ripgrep      # Fast grep (Essential for Doom Emacs)
-    fd           # Fast find (Essential for Doom Emacs)
-    jq           # JSON parser
-    tree         # Directory viewer
-    btop         # Fancy htop
-    
-    # Emacs (The Editor)
-    emacs        # The editor itself
-    
-    # Language Servers
-    nixd         # Nix LSP
-    python3
-    nodejs    
-  ];
+  imports = [ ./core.nix ];
 
-  
-  programs.git = {
-    enable = true;
-    userName = "Patrick Flynn";
-    userEmail = "big.pat@gmail.com"; # Update this!
-    extraConfig = {
-      init.defaultBranch = "main";
-      pull.rebase = true;
-    };
+  programs.zsh.shellAliases = {
+    update = "sudo nixos-rebuild switch --no-write-lock-file --refresh --flake github:patflynn/cosmo#classic-laddie";
   };
-
-  
-  programs.zsh = {
-    enable = true;
-    enableCompletion = true;
-    autosuggestion.enable = true;
-    syntaxHighlighting.enable = true;
-    
-    shellAliases = {
-      ll = "ls -l";
-      update = "sudo nixos-rebuild switch --no-write-lock-file --refresh --flake github:patflynn/cosmo#classic-laddie";
-    };
-  };
-
-  programs.starship = {
-    enable = true;
-    # Custom settings can go here
-  };
-
-  home.stateVersion = "25.11";
 }


### PR DESCRIPTION
Extracts common home-manager settings into 'home/core.nix' to allow reuse across different hosts (e.g., server, WSL, desktop). Currently applied to 'server.nix'.