### PR TITLE
Move Emacs to System Packages

### DIFF
--- a/home/core.nix
+++ b/home/core.nix
@@ -11,7 +11,6 @@
     btop         # Fancy htop
     
     # Emacs (The Editor)
-    emacs        # The editor itself
     
     # Language Servers
     nixd         # Nix LSP

--- a/hosts/classic-laddie/default.nix
+++ b/hosts/classic-laddie/default.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     ./hardware-configuration.nix
+    ../../modules/common/system.nix
   ];
 
   # Bootloader (Keep what matches your hardware!)
@@ -50,15 +51,6 @@
     settings.PasswordAuthentication = false;
     settings.PermitRootLogin = "no";
   };
-
-  # Basic System Packages
-  environment.systemPackages = with pkgs; [
-    vim
-    git
-    wget
-    curl
-    htop
-  ];
 
   # Enable Flakes and new command line tools
   nix.settings.experimental-features = [ "nix-command" "flakes" ];

--- a/hosts/wsl/default.nix
+++ b/hosts/wsl/default.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     # No hardware-configuration.nix needed for WSL
+    ../../modules/common/system.nix
   ];
 
   wsl = {
@@ -13,14 +14,6 @@
 
   # Enable Nix Flakes
   nix.settings.experimental-features = [ "nix-command" "flakes" ];
-
-  # System Packages
-  environment.systemPackages = with pkgs; [
-    git
-    vim
-    wget
-    curl
-  ];
   
   # Set default shell to zsh system-wide (optional, but good practice if HM configures it)
   programs.zsh.enable = true;

--- a/modules/common/system.nix
+++ b/modules/common/system.nix
@@ -1,0 +1,21 @@
+{ pkgs, ... }:
+
+{
+  # Core System Packages
+  # These are installed system-wide and available to all users (including root).
+  environment.systemPackages = with pkgs; [
+    # Editors
+    vim
+    emacs
+
+    # Network Tools
+    wget
+    curl
+    
+    # System Monitor
+    htop
+    
+    # Version Control
+    git
+  ];
+}


### PR DESCRIPTION
Moves Emacs from home-manager's user packages to environment.systemPackages for all hosts (classic-laddie, wsl). This ensures Emacs is available system-wide.