### PR TITLE
Fix Home Manager Git Deprecation Warnings

### DIFF
--- a/home/core.nix
+++ b/home/core.nix
@@ -21,9 +21,11 @@
 
   programs.git = {
     enable = true;
-    userName = "Patrick Flynn";
-    userEmail = "big.pat@gmail.com"; 
-    extraConfig = {
+    settings = {
+      user = {
+        name = "Patrick Flynn";
+        email = "big.pat@gmail.com"; 
+      };
       init.defaultBranch = "main";
       pull.rebase = true;
     };


### PR DESCRIPTION
Updates 'home/core.nix' to use the new  and  options, resolving deprecation warnings.