### PR TITLE
CI: Fail on Nix Evaluation Warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    env:
+      NIX_ABORT_ON_WARN: true
     steps:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v30


### PR DESCRIPTION
Sets the  environment variable in the CI workflow. This will cause Nix builds to fail if any evaluation warnings (e.g., deprecated options) are encountered, enforcing stricter code quality.