### PR TITLE
feat: Add common git and shell aliases

### DIFF
--- a/home/core.nix
+++ b/home/core.nix
@@ -27,6 +27,16 @@
       };
       init.defaultBranch = "main";
       pull.rebase = true;
+      aliases = {
+        st = "status";
+        co = "checkout";
+        ci = "commit";
+        br = "branch";
+        lg = "log --graph --abbrev-commit --decorate --format=format:'%C(bold blue)%h%C(reset) - %C(bold green)(%ar)%C(reset) %C(white)%s%C(reset) %C(dim white)- %an%C(reset)%C(bold yellow)%d%C(reset)' --all";
+        unstage = "reset HEAD --";
+        last = "log -1 HEAD";
+        cleanup = "!git branch --merged | egrep -v \"(^\\*|main|master|dev)\" | xargs git branch -d";
+      };
     };
   };
   
@@ -39,6 +49,12 @@
     shellAliases = {
       ll = "ls -l";
       ed = "emacsclient -t"; # Quick edit in terminal
+      ".." = "cd ..";
+      "..." = "cd ../..";
+      g = "git";
+      la = "ls -la";
+      grep = "grep --color=auto";
+      hm = "home-manager";
     };
 
     history = {


### PR DESCRIPTION
This commit introduces a set of common and useful aliases for Git and Zsh to home/core.nix.

Git aliases include: st, co, ci, br, lg, unstage, last, and cleanup (for merged branches).

Zsh aliases include: .., ..., g, la, grep, and hm.