### PR TITLE
docs: Update AGENTS.md with new architecture and workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,21 +1,53 @@
-# CLAUDE.md - Agent Instructions for cosmo repository
+# AGENTS.md - Context & Instructions for AI Agents
 
-## Commands
+This repository (`cosmo`) is a **Nix Flake** configuration for managing NixOS systems and Home Manager profiles.
 
-- System update: `sudo nixos-rebuild switch --flake ~/hack/cosmo --upgrade --impure`
-- Test config: `sudo nixos-rebuild test --flake ~/hack/cosmo`
-- Check NixOS version: `nixos-version`
-- List generations: `sudo nix-env --list-generations --profile /nix/var/nix/profiles/system`
-- Build for specific host: `sudo nixos-rebuild switch --flake ~/hack/cosmo#classic-laddie`
+## Project Structure & Architecture
 
-## Coding Style Guidelines
+The project follows a **Host-Centric** and **Layered** architecture.
 
-- Format: Use 2-space indentation for Nix files
-- Imports: Group imports logically, keep related imports together
-- Naming: Use camelCase for variables, descriptive names for functions
-- Structure: Follow standard Nix module structure with inputs/outputs pattern
-- Git: Use declarative commit messages, sign all commits (gitsign)
-- Prefer declarative configuration over imperative changes
-- Follow NixOS module system patterns and best practices
-- Keep configurations modular with clear separation of concerns
-- Always use the Github PR workflow without being prompted to push and generate PRs.
+- **`flake.nix`**: The entry point. Defines `nixosConfigurations` for each host (e.g., `classic-laddie`, `wsl`).
+- **`hosts/`**: Contains host-specific configurations.
+  - Each directory (e.g., `hosts/classic-laddie/`) should contain a `default.nix` (configuration) and `hardware-configuration.nix`.
+  - **`classic-laddie`** acts as a hypervisor for the **`johnny-walker`** MicroVM.
+- **`home/`**: Home Manager configurations (User: `patrick`).
+  - **`common.nix`**: Base configuration shared across all machines (shell, git, core tools).
+  - **`*.nix`** (e.g., `server.nix`, `wsl.nix`): Host/Context-specific overrides that import `common.nix`.
+  - **Note**: Home Manager is integrated as a NixOS module in `flake.nix`, not standalone.
+- **`modules/`**: Reusable NixOS modules.
+  - `modules/common/system.nix`: Base system configuration (locale, basic packages) imported by all hosts.
+- **`old-mess/`**: Legacy configuration (reference only, do not modify or use unless migrating).
+
+## Development Guidelines
+
+### 1. Conventions
+- **Language**: Nix.
+- **Formatting**: 2-space indentation.
+- **Style**: Functional, declarative. Prefer `modules` over ad-hoc shell scripts.
+- **Imports**: Explicitly import dependencies.
+
+### 2. Common Tasks
+
+#### Rebuild System
+Apply changes to the current system:
+```bash
+sudo nixos-rebuild switch --flake .
+```
+(Or `--flake .#hostname` if strictly necessary, but auto-detection usually works).
+
+#### Managing Packages
+- **System-wide** (available to root & all users):
+  - Edit `modules/common/system.nix` (for all hosts) or `hosts/<hostname>/default.nix` (for specific host).
+  - Add to `environment.systemPackages`.
+- **User-specific** (Home Manager):
+  - Edit `home/common.nix` (for all hosts) or `home/<context>.nix` (for specific context).
+  - Add to `home.packages`.
+
+### 3. Contribution Workflow
+- **Branch Protection**: The `main` branch is protected. All changes must be submitted via Pull Requests (PRs).
+- **Commit Style**: Use declarative commit messages (e.g., "feat: Add new feature", "fix: Resolve bug").
+
+## Contextual Knowledge
+- **User**: The primary configured user in Nix modules is `patrick`.
+- **WSL**: The `wsl` host configuration handles Windows Subsystem for Linux specifics.
+- **MicroVM**: `johnny-walker` is a MicroVM managed by `classic-laddie`.


### PR DESCRIPTION
Replaces the legacy AGENTS.md with updated instructions reflecting the current host-centric Nix Flake architecture, Home Manager integration, and strict PR-based contribution workflow.