### PR TITLE
docs: add clone step to johnny-walker setup guide

### DIFF
--- a/docs/johnny-walker-setup.md
+++ b/docs/johnny-walker-setup.md
@@ -7,69 +7,60 @@ This guide details the setup for the `johnny-walker` development environment.
 
 - **Host**: `classic-laddie` (NixOS, KVM/Libvirt enabled)
 - **Guest**: `johnny-walker` (NixOS, Standalone Flake Configuration)
-- **Hypervisor**: QEMU/KVM via `virt-manager`
+- **Hypervisor**: QEMU/KVM via `virsh` (headless)
 
 ## Prerequisites
 
-On `classic-laddie`, ensure that `libvirtd` is running.
+On `classic-laddie`, ensure that `libvirtd` is installed. Note that the service might show as "inactive" or "dead"—this is normal as it uses socket activation and will start automatically when accessed.
+
+## Step 1: Build Disk Image (on WSL2/Dev Machine)
+
+Instead of manually installing from ISO, we build a bootable QCOW2 image directly from the flake on your development machine (e.g., WSL2).
 
 ```bash
-# Verify libvirtd
-systemctl status libvirtd
-```
-
-## Step 1: Build Disk Image
-
-Instead of manually installing from ISO, we build a bootable QCOW2 image directly from the flake.
-
-```bash
-# Navigate to your cosmo clone
+# Navigate to your cosmo clone on your dev machine
 cd ~/hack/cosmo
 
 # Build the image
 nix build .#johnny-walker-image
 
-# The result is a symlink 'result'. The actual file path is:
-readlink -f result
-# Example: /nix/store/...-nixos-image-25.05.../nixos.qcow2
+# The result is a symlink 'result'.
 ```
 
-## Step 2: Prepare Disk
+## Step 2: Transfer Artifacts to classic-laddie (from WSL2/Dev Machine)
 
-Copy the built image to a persistent location. **Do not use the symlink directly** as it is read-only and will be garbage collected.
+We need to copy the image to the host.
+**Note**: We copy to your home directory first because `scp` cannot write directly to `/var/lib/libvirt` without root permissions, and `sudo scp` would lose your SSH keys.
 
 ```bash
-# Create directory
-sudo mkdir -p /var/lib/libvirt/images
+# 1. Copy image to your home directory on classic-laddie
+# Replace 'user' with your username (e.g., patrick)
+# Note: 'result' is a directory containing the qcow2 file
+scp $(readlink -f result)/nixos.qcow2 user@classic-laddie:~/johnny-walker.qcow2
 
-# Copy image (Rename it to johnny-walker.qcow2)
-sudo cp $(readlink -f result) /var/lib/libvirt/images/johnny-walker.qcow2
+# 2. Move image to the final location (requires sudo on host)
+ssh user@classic-laddie "sudo mkdir -p /var/lib/libvirt/images"
+ssh user@classic-laddie "sudo mv ~/johnny-walker.qcow2 /var/lib/libvirt/images/"
 
-# Set permissions
-sudo chmod 644 /var/lib/libvirt/images/johnny-walker.qcow2
-sudo chown libvirt-qemu:kvm /var/lib/libvirt/images/johnny-walker.qcow2
+# 3. Set permissions
+ssh user@classic-laddie "sudo chmod 644 /var/lib/libvirt/images/johnny-walker.qcow2"
+# Usually owned by root:root on NixOS, which is fine for libvirt
+ssh user@classic-laddie "sudo chown root:root /var/lib/libvirt/images/johnny-walker.qcow2"
 ```
 
-## Step 3: Create VM (virsh)
+## Step 3: Define and Start VM (on classic-laddie, via SSH)
 
-Instead of using `virt-manager`, we can define and start the VM using `virsh` commands.
+Define and start the VM on `classic-laddie` using `virsh`. The XML definition is piped from your local machine.
 
-1.  **Locate XML Definition**: The VM definition is checked into the repository at `hosts/johnny-walker/libvirt-domain.xml`.
-    
-    *Note: Adjust the network source in this file (`virbr0` or `enp4s0`) if necessary for your `classic-laddie` host network configuration.*
+```bash
+# Define the VM on classic-laddie (run from your dev machine/WSL2)
+# Ensure you are in the cosmo repo directory on your dev machine
+cd ~/hack/cosmo
+cat hosts/johnny-walker/libvirt-domain.xml | ssh user@classic-laddie "virsh define /dev/stdin"
 
-2.  **Define the VM**:
-
-    ```bash
-    cd ~/hack/cosmo
-    virsh define hosts/johnny-walker/libvirt-domain.xml
-    ```
-
-3.  **Start the VM**:
-
-    ```bash
-    virsh start johnny-walker
-    ```
+# Start the VM on classic-laddie (run from your dev machine/WSL2)
+ssh user@classic-laddie "virsh start johnny-walker"
+```
 
 The VM `johnny-walker` should now be defined and started on your `classic-laddie` host. You can connect to it via SSH (assuming the VM successfully boots and gets an IP on the bridge).
 

--- a/hosts/johnny-walker/libvirt-domain.xml
+++ b/hosts/johnny-walker/libvirt-domain.xml
@@ -31,7 +31,7 @@
       <model type='virtio'/>
     </interface>
     <serial type='pty'>
-      <target type='system' port='0'/>
+      <target port='0'/>
     </serial>
     <console type='pty'>
       <target type='serial' port='0'/>


### PR DESCRIPTION
Updates the setup guide to explicitely instruct cloning the repository on , ensuring the required build artifacts and XML definitions are available.