### PR TITLE
fix: enable UEFI firmware for johnny-walker

### DIFF
--- a/hosts/johnny-walker/libvirt-domain.xml
+++ b/hosts/johnny-walker/libvirt-domain.xml
@@ -5,6 +5,7 @@
   <vcpu placement='static'>24</vcpu>
   <os>
     <type arch='x86_64' machine='pc-q35-7.2'>hvm</type>
+    <loader readonly='yes' type='pflash'>/run/libvirt/nix-ovmf/edk2-x86_64-code.fd</loader>
     <boot dev='hd'/>
   </os>
   <features>


### PR DESCRIPTION
Updates the VM XML to use the UEFI firmware (`edk2-x86_64-code.fd`). This is required because the NixOS guest configuration uses `systemd-boot`, which is UEFI-only.