### PR TITLE
fix: use ESP label for boot partition

### DIFF
--- a/hosts/johnny-walker/hardware-configuration.nix
+++ b/hosts/johnny-walker/hardware-configuration.nix
@@ -19,7 +19,7 @@
     };
 
   fileSystems."/boot" =
-    { device = "/dev/disk/by-label/boot";
+    { device = "/dev/disk/by-label/ESP";
       fsType = "vfat";
     };
 


### PR DESCRIPTION
Updates `hardware-configuration.nix` to mount `/boot` from `/dev/disk/by-label/ESP`. The `nixos-generators` qcow format creates an EFI partition labeled `ESP`, not `boot`, causing boot failure in emergency mode.