### PR TITLE
feat: add github-cli and gemini-cli to dev environment

### DIFF
--- a/home/dev.nix
+++ b/home/dev.nix
@@ -13,6 +13,10 @@
     # Build Tools
     gnumake
     gcc
+
+    # CLIs
+    github-cli # GitHub CLI (gh)
+    gemini-cli # Gemini CLI
   ];
   
   # Git adjustments for dev if needed (e.g. signing keys)


### PR DESCRIPTION
Adds `github-cli` (gh) and `google-gemini-cli` to the development environment defined in `home/dev.nix`. This will allow easier interaction with GitHub and the Gemini API directly from development machines.