### PR TITLE
feat: Enable Virtio-GPU 3D acceleration for johnny-walker VM\n\nThis …

### DIFF
--- a/docs/johnny-walker-setup.md
+++ b/docs/johnny-walker-setup.md
@@ -8,6 +8,7 @@ This guide details the setup for the `johnny-walker` development environment.
 - **Host**: `classic-laddie` (NixOS, KVM/Libvirt enabled)
 - **Guest**: `johnny-walker` (NixOS, Standalone Flake Configuration)
 - **Hypervisor**: QEMU/KVM via `virsh` (headless)
+- **Graphics**: Virtio-GPU with 3D Acceleration (requires Host GPU)
 
 ## Prerequisites
 

--- a/hosts/johnny-walker/default.nix
+++ b/hosts/johnny-walker/default.nix
@@ -22,6 +22,9 @@
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 
+  # Enable Graphics
+  hardware.graphics.enable = true;
+
   networking.hostName = "johnny-walker";
   networking.networkmanager.enable = true;
 

--- a/hosts/johnny-walker/libvirt-domain.xml
+++ b/hosts/johnny-walker/libvirt-domain.xml
@@ -41,11 +41,14 @@
       <address type='virtio-serial' controller='0' bus='0' port='1'/>
     </channel>
     <graphics type='spice' autoport='yes'>
-      <listen type='address'/>
+      <listen type='none'/>
       <image compression='off'/>
+      <gl enable='yes'/>
     </graphics>
     <video>
-      <model type='virtio' vram='16384' heads='1' primary='yes'/>
+      <model type='virtio' heads='1' primary='yes'>
+        <acceleration accel3d='yes'/>
+      </model>
     </video>
     <memballoon model='virtio'>
       <address type='pci' domain='0x0000' bus='0x05' slot='0x00' function='0x0'/>


### PR DESCRIPTION
…commit enables Virtio-GPU (Virgl) 3D acceleration for the johnny-walker virtual machine. It involves enabling hardware graphics in the NixOS guest configuration and updating the Libvirt XML to utilize 3D acceleration. The documentation has also been updated to reflect these changes. This approach provides a performant and stable GPU acceleration without complex PCI passthrough setups. Remember to rebuild the VM, re-define it with the updated XML, and restart for changes to take effect.