### PR TITLE
feat/catppuccin theme

### DIFF
--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -28,8 +28,8 @@
         gaps_in = 5;
         gaps_out = 10;
         border_size = 2;
-        "col.active_border" = "rgba(33ccffee) rgba(00ff99ee) 45deg";
-        "col.inactive_border" = "rgba(595959aa)";
+        "col.active_border" = "rgb(cba6f7) rgb(94e2d5) 45deg"; # Catppuccin Mocha Mauve -> Teal
+        "col.inactive_border" = "rgb(585b70)"; # Catppuccin Mocha Surface2
         layout = "dwindle";
       };
 
@@ -45,7 +45,7 @@
           enabled = true;
           range = 4;
           render_power = 3;
-          color = "rgba(1a1a1aee)";
+          color = "rgba(1e1e2eee)"; # Catppuccin Mocha Base
         };
       };
 

--- a/home/workstation.nix
+++ b/home/workstation.nix
@@ -12,11 +12,41 @@
 
   # Essential workstation packages (User Level)
   home.packages = with pkgs; [
-    kitty # Terminal
     wofi # App launcher
     kdePackages.dolphin # File manager
     bibata-cursors
   ];
+
+  # --- Theming ---
+  gtk = {
+    enable = true;
+    theme = {
+      name = "Catppuccin-Mocha-Standard-Blue-Dark";
+      package = pkgs.catppuccin-gtk.override {
+        accents = [ "blue" ];
+        size = "standard";
+        tweaks = [
+          "rimless"
+          "black"
+        ];
+        variant = "mocha";
+      };
+    };
+    iconTheme = {
+      name = "Papirus-Dark";
+      package = pkgs.papirus-icon-theme;
+    };
+  };
+
+  # --- Programs ---
+  programs.kitty = {
+    enable = true;
+    themeFile = "Catppuccin-Mocha"; # Built-in to Nix Home Manager's Kitty module
+    settings = {
+      font_size = 12;
+      window_padding_width = 4;
+    };
+  };
 
   home.pointerCursor = {
     gtk.enable = true;


### PR DESCRIPTION
- **fix(hyprland): update deprecated config and add nvidia env vars**
- **feat(ui): set Bibata-Modern-Ice as default cursor theme**
- **feat(ui): apply Catppuccin Mocha theme to Hyprland, GTK, and Kitty**
