### PR TITLE
fix(workstation): set hyprland as default display manager session

### DIFF
--- a/modules/common/workstation.nix
+++ b/modules/common/workstation.nix
@@ -12,6 +12,7 @@
     enable = true;
     wayland.enable = true;
   };
+  services.displayManager.defaultSession = "hyprland";
 
   # Hint Electron apps to use Wayland
   environment.sessionVariables = {


### PR DESCRIPTION
Sets `services.displayManager.defaultSession = "hyprland"` in the common workstation module to ensure Hyprland starts automatically on boot/login.