### PR TITLE
fix(hyprland): ensure workspace 1 is active on remote session

### DIFF
--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -17,6 +17,9 @@
         "HDMI-A-2, disable"
         "HDMI-A-3, disable"
         "HDMI-A-4, disable"
+        "DP-1, disable"
+        "DP-2, disable"
+        "DP-3, disable"
         ", preferred, auto, 1"
       ];
 

--- a/home/scripts/sunshine-resolution.sh
+++ b/home/scripts/sunshine-resolution.sh
@@ -79,6 +79,10 @@ fi
 echo "Setting resolution for $MONITOR to ${WIDTH}x${HEIGHT}@${FPS}" >> "$LOG_FILE"
 hyprctl keyword monitor "$MONITOR, ${WIDTH}x${HEIGHT}@${FPS}, 0x0, 1" >> "$LOG_FILE" 2>&1
 
+echo "Moving Workspace 1 to $MONITOR and switching to it..." >> "$LOG_FILE"
+hyprctl dispatch moveworkspacetomonitor 1 "$MONITOR" >> "$LOG_FILE" 2>&1
+hyprctl dispatch workspace 1 >> "$LOG_FILE" 2>&1
+
 echo "Ensuring graphical-session.target is started..." >> "$LOG_FILE"
 systemctl --user start graphical-session.target >> "$LOG_FILE" 2>&1
 


### PR DESCRIPTION
This change disables common physical display outputs and explicitly moves workspace 1 to the active monitor during sunshine initialization to prevent defaulting to workspace 2.