### PR TITLE
fix(bud-lite): generate separate metadata and rootfs tarballs

### DIFF
--- a/.github/workflows/build-host-image.yml
+++ b/.github/workflows/build-host-image.yml
@@ -25,10 +25,28 @@ jobs:
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - name: Build ${{ inputs.host }} Image
+        if: inputs.host == 'bud-lite'
+        run: |
+          nix build .#bud-lite-metadata --out-link result-metadata
+          nix build .#bud-lite-rootfs --out-link result-rootfs
+
+      - name: Build ${{ inputs.host }} Image
+        if: inputs.host != 'bud-lite'
         run: nix build .#${{ inputs.host }}-image
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
+        if: inputs.host == 'bud-lite'
+        with:
+          name: bud-lite-lxc
+          path: |
+            result-metadata/*
+            result-rootfs/*
+          if-no-files-found: error
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        if: inputs.host != 'bud-lite'
         with:
           name: ${{ inputs.host }}-image
           path: result/*

--- a/flake.nix
+++ b/flake.nix
@@ -115,7 +115,25 @@
       };
 
       packages.x86_64-linux = {
-        bud-lite-image = nixos-generators.nixosGenerate {
+        bud-lite-metadata = nixos-generators.nixosGenerate {
+          system = "x86_64-linux";
+          specialArgs = { inherit inputs; };
+          modules = [
+            ./hosts/bud-lite/default.nix
+            inputs.nixos-crostini.nixosModules.crostini
+            agenix.nixosModules.default
+            home-manager.nixosModules.home-manager
+            {
+              home-manager.useGlobalPkgs = true;
+              home-manager.useUserPackages = true;
+              home-manager.extraSpecialArgs = { inherit inputs; };
+              home-manager.users.patrick = import ./home/dev.nix;
+            }
+          ];
+          format = "lxc-metadata";
+        };
+
+        bud-lite-rootfs = nixos-generators.nixosGenerate {
           system = "x86_64-linux";
           specialArgs = { inherit inputs; };
           modules = [


### PR DESCRIPTION
This PR fixes the LXC import issue by generating separate metadata and rootfs tarballs for bud-lite. Standard LXC/LXD imports require the metadata.yaml to be present in a separate tarball or as part of a split import.