### PR TITLE
refactor(bud-lite): complete transition to standalone home-manager

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -94,27 +94,35 @@
       };
 
       homeConfigurations = {
-        "patrick@bud-lite" = home-manager.lib.homeManagerConfiguration {
-          pkgs = nixpkgs.legacyPackages.x86_64-linux;
-          extraSpecialArgs = { inherit inputs; };
-          modules = [
-            ./home/dev.nix
-            (
-              { lib, ... }:
-              {
-                home.username = "patrick";
-                home.homeDirectory = "/home/patrick";
 
-                programs.zsh.shellAliases = {
-                  # Override common.nix 'update' alias for Home Manager standalone
-                  update = lib.mkForce "home-manager switch --flake github:patflynn/cosmo#patrick@bud-lite";
-                  # Local rebuild for testing changes
-                  rebuild = lib.mkForce "home-manager switch --flake .#patrick@bud-lite";
-                };
-              }
-            )
+        "patrick@bud-lite" = home-manager.lib.homeManagerConfiguration {
+
+          pkgs = nixpkgs.legacyPackages.x86_64-linux;
+
+          extraSpecialArgs = {
+
+            inherit inputs;
+
+            hostName = "bud-lite";
+
+          };
+
+          modules = [
+
+            ./home/crostini.nix
+
+            {
+
+              home.username = "patrick";
+
+              home.homeDirectory = "/home/patrick";
+
+            }
+
           ];
+
         };
+
       };
 
       packages.x86_64-linux = {

--- a/home/crostini.nix
+++ b/home/crostini.nix
@@ -1,0 +1,21 @@
+{
+  config,
+  pkgs,
+  lib,
+  hostName,
+  ...
+}:
+
+{
+  imports = [ ./dev.nix ];
+
+  # Crostini Specific Configuration
+  # This profile is designed for standalone Home Manager on Debian/Crostini.
+
+  programs.zsh.shellAliases = {
+    # Override common.nix 'update' alias for Home Manager standalone
+    update = lib.mkForce "home-manager switch --flake github:patflynn/cosmo#${config.home.username}@${hostName}";
+    # Local rebuild for testing changes
+    rebuild = lib.mkForce "home-manager switch --flake .#${config.home.username}@${hostName}";
+  };
+}


### PR DESCRIPTION
This PR completes the transition of `bud-lite` to a standalone Home Manager configuration.

## Changes
- **Refactor:** Extracted Crostini-specific configuration into `home/crostini.nix`, keeping `home/dev.nix` pure.
- **Cleanup:** Removed unused `hosts/bud-lite` NixOS configuration.
- **CI:** Updated workflows to check the Home Manager configuration instead of attempting to build a NixOS image for `bud-lite`.
- **Docs:** Added setup instructions in `docs/bud-lite-setup.md`.

This builds upon the previous work and ensures a clean separation of concerns.