### PR TITLE
feat(classic-laddie): add tank/personal mount and update docs

### DIFF
--- a/docs/classic-laddie-hardware.md
+++ b/docs/classic-laddie-hardware.md
@@ -34,6 +34,11 @@ This document outlines the hardware specifications of the `classic-laddie` host 
 *   **Partitions:**
     *   `/dev/sda1`: 3.6 TiB (Solaris /usr & Apple ZFS)
     *   `/dev/sda9`: 8 MiB (Solaris reserved 1)
+*   **ZFS Configuration:**
+    *   Pool: `tank`
+    *   Datasets:
+        *   `tank/media`: Mounted at `/mnt/media`
+        *   `tank/personal`: Mounted at `/mnt/personal`
 
 ## Network Interfaces
 *   **Wired Ethernet:** Intel Corporation Ethernet Controller I225-V [8086:15f3]

--- a/docs/laddie-build-2025.md
+++ b/docs/laddie-build-2025.md
@@ -64,15 +64,18 @@ zfs create rpool/home
 
 # Storage Datasets
 zfs create tank/media
+zfs create tank/personal
 
 # mount before install
 mount -t zfs rpool/root /mnt
-mkdir -p /mnt/{nix,home,boot,mnt/media}
+mkdir -p /mnt/{nix,home,boot}
 
 mount -t zfs rpool/nix /mnt/nix
 mount -t zfs rpool/home /mnt/home
 mount /dev/nvme0n1p1 /mnt/boot
-mount -t zfs tank/media /mnt/mnt/media
+
+# NOTE: We do NOT mount tank/* datasets here to prevent nixos-generate-config 
+# from adding them to hardware-configuration.nix. They are manually defined in default.nix.
 
 # generate hardware config
 nixos-generate-config --root /mnt

--- a/hosts/classic-laddie/default.nix
+++ b/hosts/classic-laddie/default.nix
@@ -87,9 +87,6 @@
   programs.dconf.enable = true; # Required for virt-manager
   environment.systemPackages = with pkgs; [ virt-manager ];
 
-  # Host-specific user configuration
-  users.users.patrick.extraGroups = [ "libvirtd" ];
-
   security.sudo.wheelNeedsPassword = true;
   # Enable SSH so you can access the server
   services.openssh = {
@@ -97,6 +94,38 @@
     settings.PasswordAuthentication = false;
     settings.PermitRootLogin = "no";
   };
+
+  # Define the media group for the service stack
+  users.groups.media = { };
+
+  # Ensure the patrick group is explicitly defined to avoid resolution errors
+  users.groups.family = { };
+
+  fileSystems."/mnt/personal" = {
+    device = "tank/personal";
+    fsType = "zfs";
+  };
+
+  fileSystems."/mnt/media" = {
+    device = "tank/media";
+    fsType = "zfs";
+  };
+
+  systemd.tmpfiles.rules = [
+    # Type Path             Mode User    Group   Age Argument
+    "d /mnt/media/movies    0775 patrick media   -   -"
+    "d /mnt/media/tv        0775 patrick media   -   -"
+    "d /mnt/media/music     0775 patrick media   -   -"
+    "d /mnt/personal/photos 0750 patrick family -   -"
+    "d /mnt/personal/videos 0750 patrick family -   -"
+  ];
+
+  # Host-specific user configuration
+  users.users.patrick.extraGroups = [
+    "libvirtd"
+    "family"
+    "media"
+  ];
 
   # Do not change this unless you reinstall the OS
   system.stateVersion = "25.11";

--- a/hosts/classic-laddie/hardware-configuration.nix
+++ b/hosts/classic-laddie/hardware-configuration.nix
@@ -51,11 +51,6 @@
     ];
   };
 
-  fileSystems."/mnt/media" = {
-    device = "tank/media";
-    fsType = "zfs";
-  };
-
   swapDevices = [ ];
 
   # Enables DHCP on each ethernet and wireless interface. In case of scripted networking


### PR DESCRIPTION
Adds the tank/personal ZFS dataset mount point to classic-laddie configuration and updates the hardware documentation and build log to reflect this change. Prevents configuration conflicts by documenting the exclusion of data drives during hardware-config generation.
