### PR TITLE
fix(media-server): add NET_RAW capability to gluetun for healthchecks

### DIFF
--- a/modules/media-server/default.nix
+++ b/modules/media-server/default.nix
@@ -158,6 +158,7 @@ in
         image = "qmcgaw/gluetun";
         capabilities = {
           NET_ADMIN = true;
+          NET_RAW = true;
         };
         environmentFiles = [ cfg.vpnSecretPath ];
         environment = {


### PR DESCRIPTION
This allows Gluetun to ping external targets (e.g. 1.1.1.1) to verify VPN connectivity and restart the tunnel automatically if it stalls.
