### PR TITLE
feat(classic-laddie): enable tailscale exit node routing

### DIFF
--- a/hosts/classic-laddie/default.nix
+++ b/hosts/classic-laddie/default.nix
@@ -66,7 +66,10 @@
   boot.supportedFilesystems = [ "zfs" ];
 
   # Remote Access (Roadmap Phase 1)
-  services.tailscale.enable = true;
+  services.tailscale = {
+    enable = true;
+    useRoutingFeatures = "server";
+  };
 
   # Set your time zone
   time.timeZone = "America/New_York";


### PR DESCRIPTION
Enables 'server' routing features for Tailscale on classic-laddie.