### PR TITLE
feat(classic-laddie): advertise tailscale exit node

### DIFF
--- a/hosts/classic-laddie/default.nix
+++ b/hosts/classic-laddie/default.nix
@@ -69,6 +69,7 @@
   services.tailscale = {
     enable = true;
     useRoutingFeatures = "server";
+    extraUpFlags = [ "--advertise-exit-node" ];
   };
 
   # Set your time zone


### PR DESCRIPTION
Enables the exit node advertisement flag for Tailscale on classic-laddie.