### PR TITLE
feat: add corporate configuration shim and dynamic gemini detection

### DIFF
--- a/home/common.nix
+++ b/home/common.nix
@@ -88,11 +88,6 @@
       # Add $HOME/bin to PATH
       export PATH="$HOME/bin:$PATH"
 
-      # Source corporate configuration if it exists (e.g. from Piper/CitC)
-      if [ -f "$HOME/.corp.zsh" ]; then
-        source "$HOME/.corp.zsh"
-      fi
-
       # Ergonomics
       setopt AUTO_CD              # cd by typing directory name
       setopt EXTENDED_HISTORY     # record timestamp of command in HISTFILE

--- a/home/identities/work.nix
+++ b/home/identities/work.nix
@@ -1,6 +1,13 @@
-{ ... }:
+{ lib, ... }:
 {
   cosmo.gemini.enable = false;
+
+  programs.zsh.initExtra = lib.mkBefore ''
+    # Source corporate configuration if it exists (e.g. from Piper/CitC)
+    if [ -f "$HOME/.corp.zsh" ]; then
+      source "$HOME/.corp.zsh"
+    fi
+  '';
 
   programs.git = {
     settings = {


### PR DESCRIPTION
This PR refactors how corporate-specific and Gemini CLI configurations are handled, and fixes the rebuild alias for non-NixOS systems.

### Changes:
- **home/dev.nix**: Added `cosmo.gemini.enable` option and updated the `rebuild` alias to support both NixOS (`nixos-rebuild`) and standalone Home Manager (`home-manager`).
- **home/identities/work.nix**: Set `cosmo.gemini.enable = false` and added corporate sourcing of `~/.corp.zsh`.
- **home/common.nix**: Cleaned up to remain generic.
- **home/identities/personal.nix**: Reverted to a clean state.