### PR TITLE
feat: add PXE boot server to classic-laddie

### DIFF
--- a/hosts/classic-laddie/default.nix
+++ b/hosts/classic-laddie/default.nix
@@ -112,6 +112,25 @@
   environment.systemPackages = with pkgs; [ virt-manager ];
 
   security.sudo.wheelNeedsPassword = true;
+
+  # ---------------------------------------------------------------------------
+  # PXE Boot Server (TFTP)
+  # ---------------------------------------------------------------------------
+  # Serves netboot.xyz for network installations
+  # Router config: Settings -> Networks -> Network Boot -> Server: 192.168.1.28, Filename: netboot.xyz.efi
+  systemd.services.tftpd = {
+    description = "TFTP Server for PXE Boot";
+    after = [ "network.target" ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      ExecStart = "${pkgs.atftp}/bin/atftpd --daemon --no-fork --logfile /var/log/atftpd.log /srv/tftp";
+      Restart = "on-failure";
+    };
+  };
+
+  # Open TFTP port
+  networking.firewall.allowedUDPPorts = [ 69 ];
+
   # Enable SSH so you can access the server
   services.openssh = {
     enable = true;
@@ -148,6 +167,8 @@
     "d /mnt/media/music     0775 ${config.cosmo.user.default} media   -   -"
     "d /mnt/personal/photos 0750 ${config.cosmo.user.default} family -   -"
     "d /mnt/personal/videos 0750 ${config.cosmo.user.default} family -   -"
+    # PXE Boot directory
+    "d /srv/tftp            0755 root    root    -   -"
   ];
 
   # Host-specific user configuration


### PR DESCRIPTION
## Summary

- Add TFTP server (atftpd) to classic-laddie for PXE network booting
- Enables installing NixOS on other machines without USB drives
- Uses netboot.xyz for flexible boot options

## Configuration Added

- `systemd.services.tftpd` - atftpd daemon serving `/srv/tftp`
- `networking.firewall.allowedUDPPorts = [ 69 ]` - TFTP port
- `systemd.tmpfiles.rules` - Creates `/srv/tftp` directory

## Setup Instructions

After deploying, run on classic-laddie:
```bash
sudo curl -L https://boot.netboot.xyz/ipxe/netboot.xyz.efi -o /srv/tftp/netboot.xyz.efi
```

Then configure router (UDM Pro):
1. Settings → Networks → Default → Advanced → Network Boot
2. Server: `192.168.1.28` (classic-laddie)
3. Filename: `netboot.xyz.efi`

## Use Case

This enables PXE booting for the weller dual-boot installation (see PR #228).

## Test plan

- [ ] Deploy to classic-laddie: `nixos-rebuild switch --flake .#classic-laddie`
- [ ] Download netboot.xyz.efi to /srv/tftp
- [ ] Configure UDM Pro network boot settings
- [ ] Test PXE boot from another machine