### PR TITLE
Enable bluetooth on weller

### DIFF
--- a/hosts/weller/default.nix
+++ b/hosts/weller/default.nix
@@ -75,6 +75,7 @@
   # ---------------------------------------------------------------------------
   hardware.bluetooth.enable = true;
   hardware.bluetooth.powerOnBoot = true;
+  environment.systemPackages = with pkgs; [ bluetuith ];
 
   # ---------------------------------------------------------------------------
   # Remote Access


### PR DESCRIPTION
## Summary
- Enable bluetooth hardware support and power-on-boot on weller
- Adds `bluetoothctl` (via bluez) for managing bluetooth devices

## Test plan
- [ ] Rebuild weller with `nixos-rebuild switch`
- [ ] Verify `bluetoothctl` is available
- [ ] Confirm bluetooth adapter powers on at boot