### PR TITLE
Set DP-2 to max resolution and refresh rate on weller

### DIFF
--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -82,6 +82,7 @@
       # Auto-detect monitors with preferred resolution
       # Format: name, resolution, position, scale
       monitor = [
+        "DP-2, highrr, auto, 1"
         ", preferred, auto, 1"
       ];
 


### PR DESCRIPTION
## Summary
- Configure Hyprland to use `highrr` for DP-2, selecting the highest refresh rate at max resolution
- Keeps the generic fallback rule for any other monitors

## Test plan
- [x] `nix flake check` passes
- [ ] Verify `hyprctl monitors` shows native resolution and max refresh rate after deploy