### PR TITLE
Enable natural scrolling in Hyprland

### DIFF
--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -91,6 +91,7 @@
         kb_layout = "us";
         follow_mouse = 1;
         sensitivity = 0; # -1.0 - 1.0, 0 means no modification.
+        natural_scroll = true;
       };
 
       # --- General ---


### PR DESCRIPTION
## Summary
- Enable macOS-style natural (inverted) scrolling for mouse wheel in Hyprland input config

## Test plan
- [x] `nix flake check` passes
- [ ] Verify scroll direction is inverted after deploy