### PR TITLE
Fix hypr-cheatsheet grep pattern

### DIFF
--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -67,8 +67,8 @@
       # Simple parser for Hyprland keybinds
       # Parses the generated config file
       conf="$HOME/.config/hypr/hyprland.conf"
-      grep "^bind =" "$conf" | \
-      sed 's/bind = //' | \
+      grep "^bind=" "$conf" | \
+      sed 's/bind=//' | \
       sed 's/, /   /g' | \
       sed 's/,/   /g' | \
       wofi --dmenu --width 1000 --height 600 -p "Keybindings"


### PR DESCRIPTION
## Summary
- The generated Hyprland config uses `bind=` (no spaces around `=`), but the cheatsheet script was grepping for `^bind =` (with spaces), resulting in an empty wofi popup

## Test plan
- [x] `nix flake check` passes
- [ ] Verify `Super + /` shows keybindings in wofi after deploy