### PR TITLE
Add antigravity IDE to dev packages

### DIFF
--- a/home/dev.nix
+++ b/home/dev.nix
@@ -30,6 +30,9 @@
         gcc
         openssl
 
+        # IDEs
+        antigravity
+
         # CLIs
         claude-code # Anthropic's CLI
         github-cli # GitHub CLI (gh)


### PR DESCRIPTION
## Summary
- Add antigravity IDE (v1.15.8) to dev.nix

## Test plan
- [x] `nix eval` passes