### PR TITLE
Add volume and audio output control to waybar

### DIFF
--- a/home/waybar.nix
+++ b/home/waybar.nix
@@ -6,7 +6,7 @@
     playerctl
     bluetuith
     pulseaudio
-    pavucontrol
+    pulsemixer
   ];
 
   # Remap bluetuith help key — kitty's keyboard protocol reports '?' without
@@ -137,7 +137,7 @@
           format-bluetooth-muted = "󰖁 {device_alias}";
           tooltip-format = "{desc}\n{volume}%";
           scroll-step = 5;
-          on-click = "pavucontrol";
+          on-click = "kitty pulsemixer";
         };
 
         bluetooth = {


### PR DESCRIPTION
## Summary
- Add pulseaudio module to waybar showing volume %, scroll to adjust, click to mute
- Click opens pavucontrol for switching between Scarlett 2i2, HDMI, and bluetooth audio outputs
- Bluetooth audio format shows headphone icon to distinguish from speakers
- Adds `pulseaudio` and `pavucontrol` packages

## Test plan
- [ ] Volume pill appears in bar between network and bluetooth
- [ ] Scroll on pill adjusts volume
- [ ] Click opens pavucontrol
- [ ] Can switch audio output between Scarlett and bluetooth headset in pavucontrol