### PR TITLE
Set Chrome as default browser for xdg-open

### DIFF
--- a/home/workstation.nix
+++ b/home/workstation.nix
@@ -16,6 +16,7 @@
     kdePackages.dolphin # File manager
     bibata-cursors
     google-chrome
+    xdg-desktop-portal-gtk # Portal backend for URL opening, file chooser, etc.
 
     # IDEs
     android-studio
@@ -56,6 +57,7 @@
     settings = {
       font_size = 12;
       window_padding_width = 4;
+      open_url_with = "xdg-open";
     };
   };
 
@@ -68,6 +70,9 @@
       "video/quicktime" = "mpv.desktop";
       "image/gif" = "mpv.desktop";
       "inode/directory" = "org.kde.dolphin.desktop";
+      "x-scheme-handler/http" = "google-chrome.desktop";
+      "x-scheme-handler/https" = "google-chrome.desktop";
+      "text/html" = "google-chrome.desktop";
     };
   };
 

--- a/modules/common/workstation.nix
+++ b/modules/common/workstation.nix
@@ -7,6 +7,18 @@
     xwayland.enable = true; # Required for Steam/X11 apps
   };
 
+  xdg.portal = {
+    enable = true;
+    extraPortals = with pkgs; [
+      xdg-desktop-portal-hyprland
+      xdg-desktop-portal-gtk
+    ];
+    config.common.default = [
+      "hyprland"
+      "gtk"
+    ];
+  };
+
   # Enable the Display Manager (SDDM) generically
   services.displayManager.sddm = {
     enable = true;


### PR DESCRIPTION
## Summary
- Add `x-scheme-handler/http`, `x-scheme-handler/https`, and `text/html` MIME type defaults pointing to Google Chrome
- Fixes clickable URLs in kitty (and other apps using `xdg-open`) not opening in the browser

## Test plan
- [ ] `nix flake check` passes
- [ ] After rebuild, clicking a URL in kitty opens it in Chrome
- [ ] `xdg-open https://example.com` launches Chrome