### PR TITLE
Add weller user SSH key to secrets/keys.nix

### DIFF
--- a/secrets/keys.nix
+++ b/secrets/keys.nix
@@ -5,6 +5,7 @@
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG8B2eVhu/TpXZPyOt/6w0ELdtO6X6cTiWz3CvofxDCR" # makers-mark.nixos
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHo0Oc728AfV2EMn30DhTWSqdWhmY8xR6np/qf6U7xvn cloud-ssh" # Chrome
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGCxVUxXoyFYV40QureqqSMSA17CvK9IrFB33BA6UOip" # classic-laddie
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICkzfSlbK9YX3KztdvtgfyJelixdI6QN3c41eme9HOWv" # weller
   ];
 
   # Host Keys


### PR DESCRIPTION
## Summary
- Add weller's user SSH public key (ed25519) to the `users` list in `secrets/keys.nix`

## Test plan
- [x] `nix flake check` passes