### PR TITLE
Add managed hosts comment to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,3 +1,4 @@
+# Managed hosts: classic-laddie, johnny-walker, makers-nix, weller
 {
   description = "Cosmo: Fresh Start 2025";
 


### PR DESCRIPTION
## Summary
- Adds a comment at the top of flake.nix listing the managed hosts: classic-laddie, johnny-walker, makers-nix, weller