### PR TITLE
Disable NVMe APST on weller to fix FireCuda 510 crashes

### DIFF
--- a/hosts/weller/default.nix
+++ b/hosts/weller/default.nix
@@ -39,6 +39,9 @@
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 
+  # Seagate FireCuda 510 firmware crashes with APST power saving (#263)
+  boot.kernelParams = [ "nvme_core.default_ps_max_latency_us=0" ];
+
   # ---------------------------------------------------------------------------
   # Filesystem - Btrfs with LUKS encryption (managed by disko)
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `nvme_core.default_ps_max_latency_us=0` kernel parameter to weller to disable NVMe Autonomous Power State Transition
- The Seagate FireCuda 510 firmware has a known issue where APST causes NVMe controller resets under Linux

related to #263 

## Test plan

- [ ] Rebuild weller with `nixos-rebuild switch`
- [ ] Confirm kernel param is set: `cat /proc/cmdline | grep nvme_core`
- [ ] Monitor `dmesg` for NVMe controller reset errors under sustained I/O