### PR TITLE
weller: tune Bluetooth for Kinesis Advantage 360 Pro

### DIFF
--- a/hosts/weller/default.nix
+++ b/hosts/weller/default.nix
@@ -40,7 +40,10 @@
   boot.loader.efi.canTouchEfiVariables = true;
 
   # Seagate FireCuda 510 firmware crashes with APST power saving (#263)
-  boot.kernelParams = [ "nvme_core.default_ps_max_latency_us=0" ];
+  boot.kernelParams = [
+    "nvme_core.default_ps_max_latency_us=0"
+    "btusb.enable_autosuspend=n"
+  ];
 
   # ---------------------------------------------------------------------------
   # Filesystem - Btrfs with LUKS encryption (managed by disko)
@@ -74,10 +77,33 @@
   };
 
   # ---------------------------------------------------------------------------
-  # Bluetooth
+  # Bluetooth – optimised for Kinesis Advantage 360 Pro (ZMK / BLE)
   # ---------------------------------------------------------------------------
-  hardware.bluetooth.enable = true;
-  hardware.bluetooth.powerOnBoot = true;
+  hardware.bluetooth = {
+    enable = true;
+    powerOnBoot = true;
+    settings = {
+      General = {
+        # Keep adapter in page-scan mode for instant reconnects
+        FastConnectable = "true";
+        # ZMK uses "Just Works" pairing – always allow re-pairing
+        JustWorksRepairing = "always";
+        # Better LE handling & battery reporting
+        Experimental = "true";
+      };
+      LE = {
+        # Tighter polling interval (7.5–11.25 ms) for lower input latency
+        MinConnectionInterval = 6;
+        MaxConnectionInterval = 9;
+        ConnectionLatency = 0;
+      };
+      Policy = {
+        AutoEnable = "true";
+        ReconnectAttempts = 7;
+        ReconnectIntervals = "1,2,4,8,16,32,64";
+      };
+    };
+  };
   environment.systemPackages = with pkgs; [ bluetuith ];
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Expand the minimal Bluetooth config with ZMK-optimised BlueZ settings to improve connection quality with the Kinesis Advantage 360 Pro.

## Changes

- **FastConnectable**: keeps the adapter in page-scan mode for instant reconnects after keyboard sleep
- **JustWorksRepairing = always**: prevents re-pairing loops after ZMK firmware flash or bond clear
- **Experimental**: enables improved LE handling and battery level reporting
- **LE connection interval** (7.5–11.25 ms): reduces input latency from the default ~30–50 ms
- **Reconnect policy**: 7 attempts with exponential backoff (1, 2, 4, 8, 16, 32, 64 sec)
- **`btusb.enable_autosuspend=n`**: kernel param to prevent the Realtek USB adapter from being power-suspended (common AMD/Ryzen issue)

## Post-deploy steps

1. `sudo nixos-rebuild switch --flake .#weller`
2. Remove and re-pair the keyboard for a clean bond:
   ```
   bluetoothctl remove <MAC>
   bluetoothctl scan on
   bluetoothctl pair <MAC>
   bluetoothctl trust <MAC>
   bluetoothctl connect <MAC>
   ```