### PR TITLE
Add Jellyfin and MiniDLNA to media server stack

### DIFF
--- a/modules/media-server/default.nix
+++ b/modules/media-server/default.nix
@@ -43,7 +43,12 @@ in
     ];
 
     # Allow media services to read/write to the media directory
-    users.users.plex.extraGroups = [ "media" ];
+    # render + video grants access to /dev/dri/* for NVENC hardware transcoding
+    users.users.plex.extraGroups = [
+      "media"
+      "render"
+      "video"
+    ];
     users.users.jellyfin.extraGroups = [
       "media"
       "render"


### PR DESCRIPTION
## Summary
- Adds **Jellyfin** as an open-source media server alongside Plex, with NVENC hardware transcoding and Caddy reverse proxy (`http://jellyfin`)
- Adds **MiniDLNA** for dedicated DLNA/UPnP music streaming to network audio devices (Hegel H390, Devialet Phantoms)
- MiniDLNA serves `/mnt/media/music` as audio with inotify for automatic library updates

## Post-deploy steps
- Add `jellyfin` DNS record on UDM Pro pointing to classic-laddie
- Run Jellyfin setup wizard at `http://classic-laddie:8096`
- Drop FLACs/MP3s into `/mnt/media/music`

## Test plan
- [ ] `nixos-rebuild switch` on classic-laddie succeeds
- [ ] Jellyfin web UI accessible on port 8096
- [ ] Caddy reverse proxy works for `http://jellyfin`
- [ ] MiniDLNA discoverable via SSDP on the LAN
- [ ] Hegel H390 and Devialet Phantoms can browse and play music from MiniDLNA