### PR TITLE
Install klaus on all hosts and auto-update on upstream changes

### DIFF
--- a/.github/workflows/update-klaus.yml
+++ b/.github/workflows/update-klaus.yml
@@ -1,0 +1,31 @@
+name: Update Klaus
+
+on:
+  repository_dispatch:
+    types: [klaus-updated]
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  update-klaus:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@e50d5f73bfe71c2dd0aa4218de8f4afa59f8f81d # v16
+
+      - name: Update klaus in flake.lock
+        uses: DeterminateSystems/update-flake-lock@a2bbe0274e3a0c4194390a1e445f734c597ebc37 # v24
+        with:
+          inputs: klaus
+          pr-title: "chore: update klaus"
+          pr-labels: |
+            dependencies
+            automated
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/flake.nix
+++ b/flake.nix
@@ -262,9 +262,7 @@
         in
         pkgs.mkShell {
           inherit (self.checks.x86_64-linux.pre-commit-check) shellHook;
-          buildInputs = self.checks.x86_64-linux.pre-commit-check.enabledPackages ++ [
-            klaus.packages.x86_64-linux.default
-          ];
+          buildInputs = self.checks.x86_64-linux.pre-commit-check.enabledPackages;
         };
     };
 }

--- a/home/dev.nix
+++ b/home/dev.nix
@@ -40,11 +40,15 @@
 
         # Age tools
         inputs.agenix.packages."${pkgs.stdenv.hostPlatform.system}".default
+
+        # Agent orchestration
+        inputs.klaus.packages."${pkgs.stdenv.hostPlatform.system}".default
       ]
       ++ lib.optional config.cosmo.gemini.enable pkgs.gemini-cli;
 
     programs.zsh.shellAliases = {
       rebuild = "if [ -e /etc/NIXOS ]; then sudo nixos-rebuild switch --flake .; else nix run home-manager -- switch --flake .; fi";
+      rebuild-dev = "if [ -e /etc/NIXOS ]; then sudo nixos-rebuild switch --flake . --override-input klaus path:$HOME/hack/klaus; else nix run home-manager -- switch --flake . --override-input klaus path:$HOME/hack/klaus; fi";
     };
   };
 }


### PR DESCRIPTION
## Summary

- Add klaus to `home.packages` in `dev.nix` so it's installed on every host via home-manager
- Add `rebuild-dev` shell alias for local klaus development (`--override-input`)
- Remove klaus from devShell (redundant now that it's in home-manager)
- Add `update-klaus.yml` workflow triggered by `repository_dispatch` to auto-update the flake lock when klaus pushes to main

## Pipeline

```
push to klaus main
  → notify-cosmo.yml dispatches to cosmo (see patflynn/klaus PR)
  → update-klaus.yml creates PR with updated flake.lock
  → CI passes → auto-merge
  → system.autoUpgrade at 02:00 picks up new main
```

## Test plan

- [ ] `nix flake check` passes
- [ ] `rebuild` installs klaus from pinned flake.lock
- [ ] `rebuild-dev` installs klaus from local `~/hack/klaus` checkout
- [ ] Trigger `update-klaus.yml` manually via workflow_dispatch to verify it creates a PR