### PR TITLE
Add automatic screen lock after 5 minutes of inactivity

### DIFF
--- a/home/hypridle.nix
+++ b/home/hypridle.nix
@@ -1,0 +1,28 @@
+{ config, pkgs, ... }:
+
+{
+  services.hypridle = {
+    enable = true;
+    settings = {
+      general = {
+        lock_cmd = "pidof hyprlock || hyprlock";
+        before_sleep_cmd = "loginctl lock-session";
+        after_sleep_cmd = "hyprctl dispatch dpms on";
+      };
+
+      listener = [
+        # Lock screen after 5 minutes
+        {
+          timeout = 300;
+          on-timeout = "loginctl lock-session";
+        }
+        # Turn off display after 10 minutes
+        {
+          timeout = 600;
+          on-timeout = "hyprctl dispatch dpms off";
+          on-resume = "hyprctl dispatch dpms on";
+        }
+      ];
+    };
+  };
+}

--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -7,6 +7,7 @@
 
 {
   imports = [
+    ./hypridle.nix
     ./hyprlock.nix
     ./hyprpaper.nix
     ./waybar.nix


### PR DESCRIPTION
## Summary
- Add hypridle to lock the screen after 5 minutes of inactivity via `loginctl lock-session`
- Turn off display after 10 minutes idle (resumes on input)
- Lock session before sleep so the screen is secured on wake

## Test plan
- [ ] Rebuild NixOS config on a Hyprland host
- [ ] Verify hypridle service is running (`systemctl --user status hypridle`)
- [ ] Confirm screen locks after 5 minutes of inactivity
- [ ] Confirm display turns off after 10 minutes
- [ ] Confirm lock triggers before suspend/sleep