### PR TITLE
Auto-trust workspace in cosmo-agent sessions

### DIFF
--- a/scripts/cosmo-agent
+++ b/scripts/cosmo-agent
@@ -493,7 +493,7 @@ cmd_session() {
   echo ""
 
   # Run claude interactively in the worktree — foreground, user approves actions
-  (cd "$worktree" && claude) || true
+  (cd "$worktree" && claude --trust-workspace) || true
 
   echo ""
   echo "Session ${id} ended."


### PR DESCRIPTION
## Summary

- Pass `--trust-workspace` to `claude` in `cosmo-agent session` so new worktrees under `/tmp` don't require manual trust approval each time

## Test plan

- [ ] Run `cosmo-agent session` and verify no workspace trust prompt appears