### PR TITLE
Add Mako notification daemon with Waybar integration

### DIFF
--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -10,6 +10,7 @@
     ./hypridle.nix
     ./hyprlock.nix
     ./hyprpaper.nix
+    ./mako.nix
     ./waybar.nix
   ];
 
@@ -21,7 +22,6 @@
     wf-recorder # Screen recorder
     ffmpeg # For GIF conversion
     jq # JSON processor
-    libnotify # For notifications
 
     # Script to record GIF
     (pkgs.writeShellScriptBin "record-gif" ''
@@ -141,6 +141,7 @@
       # --- Layer Rules ---
       layerrule = [
         "blur on, ignore_alpha 1, match:namespace waybar"
+        "blur on, ignore_alpha 1, match:namespace notifications"
       ];
 
       # --- Keybindings ---

--- a/home/mako.nix
+++ b/home/mako.nix
@@ -1,0 +1,56 @@
+{ pkgs, ... }:
+
+{
+  home.packages = with pkgs; [
+    libnotify
+  ];
+
+  services.mako = {
+    enable = true;
+    settings = {
+      # Position & layout
+      anchor = "top-right";
+      layer = "overlay";
+      width = 350;
+      height = 150;
+      margin = "10";
+      padding = "12";
+      border-size = 2;
+      border-radius = 12;
+      max-visible = 3;
+      sort = "-time";
+
+      # Catppuccin Mocha theme
+      background-color = "#1e1e2eee";
+      text-color = "#cdd6f4";
+      border-color = "#313244";
+      progress-color = "over #cba6f7";
+
+      # Typography
+      font = "JetBrainsMono Nerd Font 11";
+
+      # Behavior
+      default-timeout = 5000;
+      ignore-timeout = 0;
+      icons = 1;
+      max-icon-size = 48;
+
+      # Actions
+      on-button-left = "dismiss";
+      on-button-middle = "none";
+      on-button-right = "dismiss-all";
+
+      # Urgency: low
+      "[urgency=low]" = {
+        border-color = "#585b70";
+        default-timeout = 3000;
+      };
+
+      # Urgency: critical
+      "[urgency=critical]" = {
+        border-color = "#f38ba8";
+        default-timeout = 0;
+      };
+    };
+  };
+}

--- a/home/waybar.nix
+++ b/home/waybar.nix
@@ -126,6 +126,7 @@ in
           "network"
           "pulseaudio"
           "bluetooth"
+          "custom/notification"
           "tray"
         ];
 
@@ -242,6 +243,14 @@ in
           on-click = "kitty bluetuith";
         };
 
+        "custom/notification" = {
+          exec = ''makoctl mode -l 2>/dev/null | grep -q do-not-disturb && echo '{"text": "󰂛", "tooltip": "Do not disturb", "class": "dnd"}' || echo '{"text": "󰂚", "tooltip": "Notifications", "class": "enabled"}"'';
+          return-type = "json";
+          interval = 5;
+          on-click = "makoctl mode -t do-not-disturb";
+          on-click-right = "makoctl dismiss -a";
+        };
+
         tray = {
           icon-size = 16;
           spacing = 8;
@@ -302,6 +311,7 @@ in
       #bluetooth,
       #custom-gpu,
       #custom-weather,
+      #custom-notification,
       #tray {
         background-color: alpha(@base, 0.85);
         border: 2px solid @surface0;
@@ -407,6 +417,14 @@ in
 
       #bluetooth.disabled,
       #bluetooth.off {
+        color: @subtext0;
+      }
+
+      #custom-notification {
+        color: @lavender;
+      }
+
+      #custom-notification.dnd {
         color: @subtext0;
       }
 


### PR DESCRIPTION
## Summary
This PR adds Mako notification daemon support to the Hyprland home configuration with full Waybar integration and Catppuccin Mocha theming.

## Key Changes
- **New Mako configuration** (`home/mako.nix`): Added complete notification daemon setup with:
  - Catppuccin Mocha color scheme
  - Positioned at top-right with 3 visible notifications max
  - JetBrainsMono Nerd Font typography
  - Urgency-based styling (low, critical)
  - Configurable timeout and action behaviors

- **Waybar integration**: 
  - Added `custom/notification` module to display notification status
  - Implements do-not-disturb toggle via `makoctl mode`
  - Shows different icons based on notification state (enabled/DND)
  - Includes dismiss-all functionality on right-click
  - Added corresponding CSS styling with lavender color for enabled state and muted color for DND

- **Hyprland configuration updates**:
  - Imported new `mako.nix` module
  - Moved `libnotify` dependency from main packages to Mako module
  - Added blur layer rule for Mako notifications namespace

## Implementation Details
- Mako polls every 5 seconds to sync Waybar notification indicator with actual DND state
- Notifications respect urgency levels with different timeout and border colors
- Critical notifications persist until manually dismissed (timeout = 0)
- Low urgency notifications timeout after 3 seconds vs default 5 seconds

https://claude.ai/code/session_01NCmkFkmuddiUSkQ321Kjyn