### PR TITLE
weller: switch to systemd-based initrd

### DIFF
--- a/hosts/weller/default.nix
+++ b/hosts/weller/default.nix
@@ -39,6 +39,7 @@
   # Windows is on Disk 0, NixOS on Disk 1 - use UEFI boot menu (F11/F12) to switch
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
+  boot.initrd.systemd.enable = true;
 
   # Seagate FireCuda 510 firmware crashes with APST power saving (#263)
   boot.kernelParams = [


### PR DESCRIPTION
## Summary
- Enable `boot.initrd.systemd.enable = true` on weller
- First step toward supporting Bluetooth in stage 1 (initrd) so the Kinesis BLE keyboard works at the LUKS passphrase prompt

## Test plan
- [ ] `nix flake check` passes (verified locally)
- [ ] Rebuild weller with `nixos-rebuild switch` and confirm it boots successfully
- [ ] Verify LUKS passphrase prompt still appears and accepts input

Run: 20260220-1657-283d