### PR TITLE
fix initrd build: include bluetooth dbus policy in makeDBusConf

### DIFF
--- a/modules/common/initrd-bluetooth.nix
+++ b/modules/common/initrd-bluetooth.nix
@@ -46,28 +46,32 @@ in
     boot.initrd.systemd.contents = {
       "/lib/firmware/rtl_bt".source = "${pkgs.linux-firmware}/lib/firmware/rtl_bt";
 
-      "/etc/dbus-1".source = let
-        bluetoothDbusPolicy = pkgs.writeTextDir "share/dbus-1/system.d/bluetooth.conf" ''
-          <!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
-            "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
-          <busconfig>
-            <policy context="default">
-              <allow own="org.bluez"/>
-              <allow send_destination="org.bluez"/>
-              <allow send_interface="org.bluez"/>
-              <allow send_interface="org.freedesktop.DBus.ObjectManager"/>
-              <allow send_interface="org.freedesktop.DBus.Properties"/>
-            </policy>
-          </busconfig>
-        '';
-      in lib.mkForce (pkgs.makeDBusConf.override {
-        suidHelper = "/bin/false";
-        serviceDirectories = [
-          pkgs.dbus
-          config.boot.initrd.systemd.package
-          bluetoothDbusPolicy
-        ];
-      });
+      "/etc/dbus-1".source =
+        let
+          bluetoothDbusPolicy = pkgs.writeTextDir "share/dbus-1/system.d/bluetooth.conf" ''
+            <!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+              "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+            <busconfig>
+              <policy context="default">
+                <allow own="org.bluez"/>
+                <allow send_destination="org.bluez"/>
+                <allow send_interface="org.bluez"/>
+                <allow send_interface="org.freedesktop.DBus.ObjectManager"/>
+                <allow send_interface="org.freedesktop.DBus.Properties"/>
+              </policy>
+            </busconfig>
+          '';
+        in
+        lib.mkForce (
+          pkgs.makeDBusConf.override {
+            suidHelper = "/bin/false";
+            serviceDirectories = [
+              pkgs.dbus
+              config.boot.initrd.systemd.package
+              bluetoothDbusPolicy
+            ];
+          }
+        );
 
       "/etc/bluetooth/main.conf".text = ''
         [General]


### PR DESCRIPTION
## Summary
- Fixes the initrd build failure introduced in #280
- The NixOS dbus module creates `/etc/dbus-1` as a symlink to a read-only store path via `makeDBusConf`. Adding `bluetooth.conf` as a separate `boot.initrd.systemd.contents` entry inside that path fails because the initrd builder cannot create files inside the immutable symlink target.
- Instead, override the dbus config source with `mkForce` to include the bluetooth policy in `makeDBusConf`'s `serviceDirectories`, so it gets baked into the generated dbus configuration alongside the default dbus and systemd policies.

## Test plan
- [ ] Run `rebuild-dev` on weller and verify the build completes without the `/etc/dbus-1/system.d` permission error
- [ ] Verify bluetooth service starts in initrd and BLE keyboard works at LUKS prompt