### PR TITLE
hyprland: add window rules and mouse bindings

### DIFF
--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -144,6 +144,12 @@
         "blur on, ignore_alpha 1, match:namespace notifications"
       ];
 
+      # --- Window Rules ---
+      # Hide Chrome's Spotify "now playing" floating popup (redundant with waybar mpris)
+      windowrulev2 = [
+        "workspace special:trash silent, class:^(google-chrome)$, floating:1, title:.*•.*"
+      ];
+
       # --- Keybindings ---
       "$mainMod" = "SUPER";
       bindd = [
@@ -202,6 +208,12 @@
         # Notifications
         "$mainMod SHIFT, N, Restore notification, exec, makoctl restore"
         "$mainMod, N, Dismiss notification, exec, makoctl dismiss"
+      ];
+
+      # --- Mouse Bindings ---
+      bindm = [
+        "ALT, mouse:272, movewindow"
+        "ALT, mouse:273, resizewindow"
       ];
 
       debug = {


### PR DESCRIPTION
## Summary
- Hide Chrome's Spotify "now playing" floating popup by sending it to a hidden special workspace (redundant with waybar mpris module)
- Add Alt + left-click/right-click mouse drag bindings for moving and resizing floating windows

## Test plan
- [ ] Rebuild config
- [ ] Play music on Spotify web, hover over media icon in Chrome — popup should no longer appear
- [ ] Alt + left-click drag a floating window to move it
- [ ] Alt + right-click drag a floating window to resize it