### PR TITLE
fix(hyprland): use windowrule instead of deprecated windowrulev2

### DIFF
--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -146,7 +146,7 @@
 
       # --- Window Rules ---
       # Hide Chrome's Spotify "now playing" floating popup (redundant with waybar mpris)
-      windowrulev2 = [
+      windowrule = [
         "workspace special:trash silent, class:^(google-chrome)$, floating:1, title:.*•.*"
       ];
 


### PR DESCRIPTION
## Summary
- Rename `windowrulev2` to `windowrule` to fix deprecation warning in newer Hyprland versions

## Test plan
- [ ] Rebuild config — no deprecation warning should appear