### PR TITLE
fix(hyprland): use new windowrule match syntax

### DIFF
--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -147,7 +147,7 @@
       # --- Window Rules ---
       # Hide Chrome's Spotify "now playing" floating popup (redundant with waybar mpris)
       windowrule = [
-        "workspace special:trash silent, class:^(google-chrome)$, floating:1, title:.*•.*"
+        "match:class ^(google-chrome)$, match:float yes, match:title .*•.*, workspace special:trash silent"
       ];
 
       # --- Keybindings ---


### PR DESCRIPTION
## Summary
- Fix windowrule syntax to use `match:class`, `match:float`, `match:title` instead of the old v2 format (`class:`, `floating:`, `title:`)

## Test plan
- [ ] Rebuild config — no config error at line 92
- [ ] Spotify popup still suppressed