### PR TITLE
Replace deprecated system arg with nixpkgs.hostPlatform

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -103,9 +103,9 @@
           email ? "big.pat@gmail.com",
         }:
         nixpkgs.lib.nixosSystem {
-          inherit system;
           specialArgs = { inherit inputs; };
           modules = [
+            { nixpkgs.hostPlatform = system; }
             hardware
             (if disk != null then disk else { })
             (if disk != null then inputs.disko.nixosModules.disko else { })
@@ -125,9 +125,9 @@
       nixosConfigurations = {
         # Hostname: classic-laddie
         classic-laddie = nixpkgs.lib.nixosSystem {
-          system = "x86_64-linux";
           specialArgs = { inherit inputs; };
           modules = [
+            { nixpkgs.hostPlatform = "x86_64-linux"; }
             ./hosts/classic-laddie/default.nix
             agenix.nixosModules.default
             microvm.nixosModules.host
@@ -164,9 +164,9 @@
 
         # Hostname: makers-nix
         makers-nix = nixpkgs.lib.nixosSystem {
-          system = "x86_64-linux";
           specialArgs = { inherit inputs; };
           modules = [
+            { nixpkgs.hostPlatform = "x86_64-linux"; }
             ./hosts/makers-nix/default.nix
             inputs.nixos-wsl.nixosModules.wsl
             agenix.nixosModules.default
@@ -191,9 +191,9 @@
 
         # Hostname: johnny-walker
         johnny-walker = nixpkgs.lib.nixosSystem {
-          system = "x86_64-linux";
           specialArgs = { inherit inputs; };
           modules = [
+            { nixpkgs.hostPlatform = "x86_64-linux"; }
             ./hosts/johnny-walker/default.nix
             agenix.nixosModules.default
             home-manager.nixosModules.home-manager
@@ -224,9 +224,9 @@
 
         # Hostname: weller (dual-boot Windows 11 + NixOS workstation)
         weller = nixpkgs.lib.nixosSystem {
-          system = "x86_64-linux";
           specialArgs = { inherit inputs; };
           modules = [
+            { nixpkgs.hostPlatform = "x86_64-linux"; }
             ./hosts/weller/default.nix
             ./hosts/weller/disk-config.nix
             inputs.disko.nixosModules.disko
@@ -252,9 +252,9 @@
 
         # Hostname: klaus-worker-0 (microVM worker for klaus agent)
         klaus-worker-0 = nixpkgs.lib.nixosSystem {
-          system = "x86_64-linux";
           specialArgs = { inherit inputs; };
           modules = [
+            { nixpkgs.hostPlatform = "x86_64-linux"; }
             microvm.nixosModules.microvm
             ./modules/klaus-worker/default.nix
             {


### PR DESCRIPTION
## Summary
- Remove deprecated top-level `system` parameter from all `nixpkgs.lib.nixosSystem` calls
- Add `{ nixpkgs.hostPlatform = "x86_64-linux"; }` to each configuration's modules list instead
- Applies to mkBootstrap helper and all 5 nixosConfigurations (classic-laddie, makers-nix, johnny-walker, weller, klaus-worker-0)
- The `nixos-generators.nixosGenerate` call in packages is left unchanged as it has a different API

## Notes
One remaining deprecation warning from `microvm.nixosModules.host` (external dependency) — not addressable in our flake.

## Test plan
- [x] `nix fmt` reports no formatting changes
- [x] `nix flake check --no-build` passes with no new warnings
- [x] Pre-commit hooks pass (nixfmt, detect-private-keys)

Run: 20260413-2102-2396