### PR TITLE
Make klaus-worker-0 microVM on-demand

### DIFF
--- a/hosts/classic-laddie/default.nix
+++ b/hosts/classic-laddie/default.nix
@@ -50,6 +50,7 @@
   # ---------------------------------------------------------------------------
   microvm.vms = {
     klaus-worker-0 = {
+      autostart = false;
       specialArgs = { inherit inputs; };
       config = {
         imports = [

--- a/hosts/classic-laddie/default.nix
+++ b/hosts/classic-laddie/default.nix
@@ -76,8 +76,11 @@
     };
   };
 
-  # Assign bridges to microVM interfaces on the host
+  # Assign bridges to microVM interfaces on the host.
+  # bindsTo + wantedBy ensure the TAP interface is brought up/down with the VM.
   systemd.services."microvm-tap-interfaces@klaus-worker-0" = {
+    wantedBy = [ "microvm@klaus-worker-0.service" ];
+    bindsTo = [ "microvm@klaus-worker-0.service" ];
     wants = [ "br-klaus-netdev.service" ];
     after = [ "br-klaus-netdev.service" ];
     postStart = "${pkgs.iproute2}/bin/ip link set vm-klaus-0 master br-klaus";


### PR DESCRIPTION
## Summary

- Set `autostart = false` on the `klaus-worker-0` microVM so it no longer starts automatically on boot or NixOS rebuild
- The systemd service `microvm@klaus-worker-0` still exists for manual management:
  ```
  sudo systemctl start microvm@klaus-worker-0
  sudo systemctl stop microvm@klaus-worker-0
  ```

## Test plan

- [x] `nix build .#nixosConfigurations.classic-laddie.config.system.build.toplevel` succeeds
- [x] Verified `microvm@klaus-worker-0` is not in `microvms.target.wants`
- [ ] After deploy, confirm VM does not start on reboot
- [ ] Confirm `systemctl start microvm@klaus-worker-0` brings up the VM with networking

Run: 20260414-0643-5ef9