### PR TITLE
Reduce Plex stop timeout to 10s on classic-laddie

### DIFF
--- a/modules/media-server/default.nix
+++ b/modules/media-server/default.nix
@@ -87,6 +87,11 @@ in
       openFirewall = true;
     };
 
+    # EasyAudioEncoder child process ignores SIGTERM and hangs for the full
+    # default 90s TimeoutStopSec.  The main Plex process exits in < 1s on
+    # SIGQUIT, so 10s is plenty before SIGKILL cleans up stragglers.
+    systemd.services.plex.serviceConfig.TimeoutStopSec = 10;
+
     services.sonarr = {
       enable = true;
       group = "media";

--- a/modules/media-server/default.nix
+++ b/modules/media-server/default.nix
@@ -88,9 +88,11 @@ in
     };
 
     # EasyAudioEncoder child process ignores SIGTERM and hangs for the full
-    # default 90s TimeoutStopSec.  The main Plex process exits in < 1s on
-    # SIGQUIT, so 10s is plenty before SIGKILL cleans up stragglers.
+    # default 90s TimeoutStopSec.  Send SIGQUIT instead — the main Plex
+    # process exits in < 1s on that signal — and allow 10s before SIGKILL
+    # cleans up stragglers.
     systemd.services.plex.serviceConfig.TimeoutStopSec = 10;
+    systemd.services.plex.serviceConfig.KillSignal = "SIGQUIT";
 
     services.sonarr = {
       enable = true;


### PR DESCRIPTION
## Summary
- Set `TimeoutStopSec = 10` for the Plex systemd service on classic-laddie
- The EasyAudioEncoder (EAE) child process ignores SIGTERM and hangs for the full default 90s timeout during shutdown; the main Plex process exits in under 1 second, so 10s is sufficient before SIGKILL

## Test plan
- [x] `nix build .#nixosConfigurations.classic-laddie.config.system.build.toplevel` succeeds
- [ ] Verify on next rebuild that shutdown no longer stalls on the Plex unit

Run: 20260414-0644-5206