### PR TITLE
Remove hardcoded UIDs, dead code, and misc hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,5 @@ tmux/
 work.nix
 zsh/
 .pre-commit-config.yaml
-\n# Local flake configurations
+# Local flake configurations
 flake.nix.local

--- a/home/hypridle.nix
+++ b/home/hypridle.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ ... }:
 
 {
   services.hypridle = {

--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -307,7 +307,7 @@
       ];
 
       debug = {
-        disable_logs = false;
+        disable_logs = true;
       };
     };
   };

--- a/home/server.nix
+++ b/home/server.nix
@@ -1,9 +1,5 @@
-{ config, pkgs, ... }:
+{ ... }:
 
 {
   imports = [ ./common.nix ];
-
-  programs.zsh.shellAliases = {
-    # System Maintenance
-  };
 }

--- a/hosts/classic-laddie/hardware-configuration.nix
+++ b/hosts/classic-laddie/hardware-configuration.nix
@@ -60,7 +60,6 @@
   # still possible to use this option, but it's recommended to use it in conjunction
   # with explicit per-interface declarations with `networking.interfaces.<interface>.useDHCP`.
   networking.useDHCP = lib.mkDefault true;
-  # networking.interfaces.enp4s0.useDHCP = lib.mkDefault true;
 
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
   hardware.cpu.amd.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;

--- a/hosts/weller/default.nix
+++ b/hosts/weller/default.nix
@@ -55,9 +55,6 @@
     user = config.cosmo.user.default;
   };
 
-  # Enable CUDA support for Sunshine
-  # services.sunshine.package = pkgs.sunshine.override { cudaSupport = true; };
-
   # ---------------------------------------------------------------------------
   # Gaming
   # ---------------------------------------------------------------------------

--- a/modules/common/remoting.nix
+++ b/modules/common/remoting.nix
@@ -80,7 +80,7 @@ in
       wants = [ "hyprland-session.target" ];
       environment = {
         WAYLAND_DISPLAY = "wayland-1";
-        XDG_RUNTIME_DIR = "/run/user/1000"; # FIXME: Assumes default user UID is 1000
+        XDG_RUNTIME_DIR = "/run/user/${toString config.users.users.${config.cosmo.user.default}.uid}";
         LD_LIBRARY_PATH = "/run/opengl-driver/lib";
       };
     };

--- a/modules/media-server/default.nix
+++ b/modules/media-server/default.nix
@@ -256,7 +256,7 @@ in
         environment = {
           PUID = "${toString config.users.users.${config.cosmo.user.default}.uid}";
           PGID = "${toString config.users.groups.media.gid}";
-          TZ = "America/New_York";
+          TZ = config.time.timeZone;
           WEBUI_PORT = "8081";
         };
         volumes = [
@@ -273,7 +273,7 @@ in
         environment = {
           PUID = "${toString config.users.users.${config.cosmo.user.default}.uid}";
           PGID = "${toString config.users.groups.media.gid}";
-          TZ = "America/New_York";
+          TZ = config.time.timeZone;
         };
         volumes = [
           "/var/lib/sabnzbd/config:/config"

--- a/modules/media-server/default.nix
+++ b/modules/media-server/default.nix
@@ -111,8 +111,7 @@ in
       openFirewall = true;
     };
 
-    # SABnzbd (Moved to container for VPN)
-    # services.sabnzbd removed.
+    # SABnzbd runs as a container below (routed through Gluetun for VPN)
 
     services.overseerr = {
       enable = true;
@@ -255,8 +254,8 @@ in
         dependsOn = [ "gluetun" ];
         extraOptions = [ "--network=container:gluetun" ];
         environment = {
-          PUID = "1000"; # ${config.cosmo.user.default}
-          PGID = "991"; # media
+          PUID = "${toString config.users.users.${config.cosmo.user.default}.uid}";
+          PGID = "${toString config.users.groups.media.gid}";
           TZ = "America/New_York";
           WEBUI_PORT = "8081";
         };
@@ -272,8 +271,8 @@ in
         dependsOn = [ "gluetun" ];
         extraOptions = [ "--network=container:gluetun" ];
         environment = {
-          PUID = "1000"; # ${config.cosmo.user.default}
-          PGID = "991"; # media
+          PUID = "${toString config.users.users.${config.cosmo.user.default}.uid}";
+          PGID = "${toString config.users.groups.media.gid}";
           TZ = "America/New_York";
         };
         volumes = [


### PR DESCRIPTION
## Summary

- Replace hardcoded UID 1000 and GID 991 with dynamic config lookups (`config.users.users.*.uid` / `config.users.groups.media.gid`) in `remoting.nix` and `media-server/default.nix`
- Fix malformed `.gitignore` line containing a literal `\n` prefix
- Disable hyprland debug logging, clean up misleading comments, remove commented-out code, and drop unused function arguments
- All 10 applicable items from the cleanup checklist addressed (item 10 skipped — file no longer exists)

## Test plan

- [x] `nix flake check` passes with all changes applied

Run: 20260418-2152-cd36
Fixes #298