### PR TITLE
Use quick fade animation for workspace switches

### DIFF
--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -165,6 +165,13 @@
         };
       };
 
+      # --- Animations ---
+      animations = {
+        animation = [
+          "workspaces, 1, 2, default, fade"
+        ];
+      };
+
       # --- Cursor ---
       cursor = {
         no_hardware_cursors = true;

--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -167,6 +167,7 @@
 
       # --- Animations ---
       animations = {
+        enabled = true;
         animation = [
           "workspaces, 1, 2, default, fade"
         ];


### PR DESCRIPTION
## Summary
- Replace the default slide animation with a fast crossfade (200ms) for workspace transitions
- The slide animation was distracting on the 5120x2160 ultrawide

## Test plan
- [x] Tested live via `hyprctl keyword animation "workspaces, 1, 2, default, fade"`
- [ ] Rebuild with `nixos-rebuild switch` to confirm persistent config

🤖 Generated with [Claude Code](https://claude.com/claude-code)