### PR TITLE
Move rebuild resource caps from nix-daemon to the units that own the build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,10 @@ We prefer **Jujutsu (jj)** for local development, especially for managing stacke
 ### 4. Common Tasks
 
 #### Rebuild System
-Apply changes to the current system:
+Apply changes to the current system. Prefer the `cosmo-rebuild` wrapper for
+interactive rebuilds — it runs `nixos-rebuild` inside a memory-bounded,
+idle-scheduled transient scope so heavy builds (e.g. `rusty-v8`,
+`home-assistant`) can't wedge the desktop session.
 ```bash
-sudo nixos-rebuild switch --flake .
+cosmo-rebuild switch --flake .
+```

--- a/hosts/classic-laddie/default.nix
+++ b/hosts/classic-laddie/default.nix
@@ -194,6 +194,13 @@
       TimeoutStartSec = 600;
       StartLimitIntervalSec = 300;
       StartLimitBurst = 3;
+      # Build subprocesses inherit this unit's cgroup, so the caps actually
+      # constrain the rebuild — unlike daemon-targeted limits, which don't
+      # apply when nixos-rebuild runs the build directly in its own process
+      # tree (see PR #515 follow-up).
+      MemoryHigh = "80%";
+      CPUSchedulingPolicy = "idle";
+      IOSchedulingClass = "idle";
     };
     path = with pkgs; [
       git

--- a/modules/common/system.nix
+++ b/modules/common/system.nix
@@ -24,6 +24,10 @@
 
     # Core System Packages
     # These are installed system-wide and available to all users (including root).
+    # Includes `cosmo-rebuild`, an interactive wrapper around `nixos-rebuild`
+    # that runs the build inside a transient idle-scheduled scope so a heavy
+    # rebuild can't outcompete the desktop for RAM/CPU and wedge the session
+    # (sudo'd nixos-rebuild otherwise inherits the invoking shell's cgroup).
     environment.systemPackages = with pkgs; [
       # Editors
       vim
@@ -38,6 +42,15 @@
 
       # Version Control
       git
+
+      # Interactive rebuild wrapper
+      (writeShellScriptBin "cosmo-rebuild" ''
+        exec sudo systemd-run --scope --slice=cosmo-rebuild.slice \
+          -p MemoryHigh=20G \
+          -p CPUSchedulingPolicy=idle \
+          -p IOSchedulingClass=idle \
+          nixos-rebuild "$@"
+      '')
     ];
 
     # Enable Flakes and new command line tools
@@ -50,17 +63,11 @@
       download-buffer-size = 67108864;
       # Cap build parallelism so the nightly auto-upgrade can't saturate RAM
       # and wedge a live desktop session (see classic-laddie 2026-04-28 hang).
+      # Honored by every nix invocation regardless of whether builds run via
+      # the daemon or directly in a sudo'd nixos-rebuild's own process tree.
       max-jobs = lib.mkDefault 2;
       cores = lib.mkDefault 4;
     };
-
-    # Run nix-daemon (and its build children) at SCHED_IDLE / IO class "idle"
-    # so they only get CPU and disk bandwidth when nothing interactive wants
-    # them. Complements the memory caps above: those bound how much; these
-    # bound when. Together they make the nightly auto-upgrade essentially
-    # invisible to a live desktop session.
-    nix.daemonCPUSchedPolicy = lib.mkDefault "idle";
-    nix.daemonIOSchedClass = lib.mkDefault "idle";
 
     # Automate Maintenance
     # Update the system daily from the upstream repo and clean up old generations
@@ -74,6 +81,17 @@
       ];
       dates = "02:00";
       randomizedDelaySec = "45min";
+    };
+
+    # Cap the nightly upgrade unit itself. `sudo nixos-rebuild` builds run in
+    # the invoking user's terminal cgroup (e.g. the kitty scope), not under
+    # nix-daemon, so daemon-targeted limits don't constrain them. Capping the
+    # systemd unit that actually drives the rebuild does — its build
+    # subprocesses inherit this cgroup.
+    systemd.services.nixos-upgrade.serviceConfig = {
+      MemoryHigh = lib.mkDefault "80%";
+      CPUSchedulingPolicy = lib.mkDefault "idle";
+      IOSchedulingClass = lib.mkDefault "idle";
     };
 
     nix.gc = {
@@ -95,10 +113,5 @@
       enable = true;
       enableSystemSlice = lib.mkDefault true;
     };
-
-    # Backstop: cap nix-daemon at a fraction of host RAM so a single build can't
-    # eat the whole machine during the nightly auto-upgrade window. Percentage
-    # keeps this portable across hosts with very different memory sizes.
-    systemd.services.nix-daemon.serviceConfig.MemoryHigh = lib.mkDefault "80%";
   };
 }

--- a/modules/common/system.nix
+++ b/modules/common/system.nix
@@ -45,11 +45,11 @@
 
       # Interactive rebuild wrapper
       (writeShellScriptBin "cosmo-rebuild" ''
-        exec sudo systemd-run --scope --slice=cosmo-rebuild.slice \
-          -p MemoryHigh=20G \
+        exec sudo ${pkgs.systemd}/bin/systemd-run --scope --slice=cosmo-rebuild.slice \
+          -p MemoryHigh=80% \
           -p CPUSchedulingPolicy=idle \
           -p IOSchedulingClass=idle \
-          nixos-rebuild "$@"
+          ${pkgs.nixos-rebuild}/bin/nixos-rebuild "$@"
       '')
     ];
 


### PR DESCRIPTION
## Summary

Follow-up to #515. The resource caps added there target `nix-daemon.service`, but `sudo nixos-rebuild` builds don't actually run under that cgroup — confirmed live on classic-laddie by inspecting `/proc/<pid>/cgroup`:

- The active `nix build` doing the work was in the user's terminal scope (`/user.slice/user-1000.slice/user@1000.service/kitty-8601-0.scope`), honoring `--max-jobs 2 --cores 4` from `nix.conf`.
- `nix-daemon` itself (PID 2991 at the time) sat at `TasksCurrent=17`, `MemoryCurrent=7MB` — barely involved.

So three of the #515 knobs are no-ops for the failure mode that motivated that PR (a sudo'd nightly rebuild wedging the desktop). They still help non-root users invoking `nix build` via the daemon, but that path isn't classic-laddie's.

This narrows the protection to the paths that actually need it.

## Changes

**Removed** (daemon-targeted, don't constrain sudo'd rebuilds):
- `nix.daemonCPUSchedPolicy = "idle"`
- `nix.daemonIOSchedClass = "idle"`
- `systemd.services.nix-daemon.serviceConfig.MemoryHigh = "80%"`

**Kept** (work everywhere — `nix.conf` settings consumed by every nix invocation, plus kernel/system-wide knobs):
- `nix.settings.max-jobs = 2`, `nix.settings.cores = 4`
- `vm.swappiness = 10`
- `systemd.oomd.enable` + `enableSystemSlice`

**Added**:
- `MemoryHigh = "80%"` + `CPUSchedulingPolicy/IOSchedulingClass = "idle"` on `nixos-upgrade.service` (the unit `system.autoUpgrade` creates for the nightly). Build subprocesses inherit the unit's cgroup, so this actually bites.
- Same caps on classic-laddie's `cosmo-rebuild.service` (webhook-triggered rebuild).
- A `cosmo-rebuild` wrapper on the system PATH that runs `nixos-rebuild` inside a transient idle-scheduled scope (`systemd-run --scope --slice=cosmo-rebuild.slice -p MemoryHigh=20G -p CPUSchedulingPolicy=idle -p IOSchedulingClass=idle nixos-rebuild "$@"`) so manual rebuilds get the same protection. AGENTS.md updated to recommend it for interactive rebuilds.

## Test plan

- [ ] CI green (`nix build … --dry-run` for each host config; `nixfmt --check`; `nix flake check`).
- [ ] Post-merge, on classic-laddie: `systemctl show cosmo-rebuild.service -p MemoryHigh -p CPUSchedulingPolicy -p IOSchedulingClass` reflects the new caps.
- [ ] Post-merge, on classic-laddie: `which cosmo-rebuild` resolves and `cosmo-rebuild dry-build --flake .` exercises the wrapper.
- [ ] Next nightly upgrade window: confirm the desktop stays responsive (the original #515 motivating failure).

Run: 20260429-2237-5d24