### PR TITLE
classic-laddie: force-load NVIDIA modules in initrd to fix 1024x768 framebuffer

### DIFF
--- a/hosts/classic-laddie/hardware.nix
+++ b/hosts/classic-laddie/hardware.nix
@@ -46,7 +46,6 @@
   boot.initrd.kernelModules = [
     "nvidia"
     "nvidia_modeset"
-    "nvidia_uvm"
     "nvidia_drm"
   ];
 

--- a/hosts/classic-laddie/hardware.nix
+++ b/hosts/classic-laddie/hardware.nix
@@ -38,6 +38,18 @@
     package = config.boot.kernelPackages.nvidiaPackages.stable;
   };
 
+  # Force-load NVIDIA display modules in initrd so the GPU drives the
+  # framebuffer from boot. Without this, hardware.nvidia.modesetting.enable
+  # wasn't enough on driver 595.58.03 + linux-zen 6.19.12 — the kernel
+  # command line set nvidia-drm.modeset=1 but nothing actually loaded
+  # nvidia_drm, leaving Hyprland stuck on EFI fb at 1024x768.
+  boot.initrd.kernelModules = [
+    "nvidia"
+    "nvidia_modeset"
+    "nvidia_uvm"
+    "nvidia_drm"
+  ];
+
   # Allow qemu-libvirtd to access the GPU
   users.groups.video.members = [ "qemu-libvirtd" ];
   users.groups.render.members = [ "qemu-libvirtd" ];


### PR DESCRIPTION
## Symptom

After last night's rebuild on `classic-laddie` (Generation 261, NixOS 26.05.20260427.1c3fe55, NVIDIA driver 595.58.03), Hyprland came up at **1024×768** — the EFI simple-framebuffer resolution — instead of the monitor's native mode.

## Root cause

`hardware.nvidia.modesetting.enable = true` was already set, and the kernel command line correctly contained `nvidia-drm.modeset=1 nvidia-drm.fbdev=1`. But the NVIDIA DRM/modeset modules were never actually being loaded at boot:

- `lsmod` showed only `nvidia` and `nvidia_uvm`; `nvidia_drm` and `nvidia_modeset` were absent.
- `/dev/dri/` had only `card0` (the EFI simple-framebuffer) — no NVIDIA DRM device.
- `/sys/module/nvidia_drm` did not exist at all.
- `nvidia-drm.ko` was present at `/run/booted-system/kernel-modules/lib/modules/6.19.12-zen1/misc/nvidia-drm.ko` — i.e., the module was built, just never loaded.

By the time the modesetting kernel arg gets evaluated, the EFI simple-framebuffer has already grabbed the display, and nothing is triggering the load of `nvidia_drm`. The result: Hyprland is stuck on the EFI fb.

After `sudo modprobe nvidia_drm` the modules loaded, `card1` + `renderD128` appeared in `/dev/dri/`, and a display-manager restart brought up the desktop at native resolution. So the modules work — they just weren't autoloading early enough.

This appears to be a regression from the NVIDIA 595.x bump and/or the linux-zen 6.19.12 initramfs path; the explicit fix is to force the modules into the initrd.

## Fix

Add the NVIDIA display modules to `boot.initrd.kernelModules` on `classic-laddie` so they're loaded before any framebuffer console is established. This is host-specific (the only NVIDIA box) so the change lives in `hosts/classic-laddie/hardware.nix` rather than a common module.

## Why initrd-level loading

Loading these via `boot.kernelModules` (post-boot) would still leave a window where the EFI framebuffer drives the console; loading them in the initrd ensures `nvidia_drm` is present before the kernel decides who owns the framebuffer, which is how `nvidia-drm.modeset=1` actually takes effect.

## Confirmation

User has already verified that manual `modprobe nvidia_drm` (followed by a display-manager restart) restores native resolution on this exact build. This PR just makes that load happen automatically at every boot.

## Test plan

- [ ] CI dry-run build passes (no local nix tooling used per host constraints).
- [ ] After merge + reboot on classic-laddie: `lsmod | grep nvidia` shows all four modules; `ls /dev/dri/` includes `card1` and `renderD128`; Hyprland comes up at native resolution without manual intervention.

Run: 20260430-1040-34d5