### PR TITLE
system.nix: OS-level memory protection (split universal vs desktop-only)

### DIFF
--- a/modules/common/desktop.nix
+++ b/modules/common/desktop.nix
@@ -88,4 +88,32 @@
       xdg-document-portal = restartPolicy;
       xdg-permission-store = restartPolicy;
     };
+
+  # --- Interactive-session memory protection ---
+  # Keep a heavy build (sudo'd, agent-launched, or manual) from wedging the
+  # live desktop session. Scoped to desktop.nix because these settings only
+  # make sense when system.slice is *background* work and user.slice is the
+  # interactive session worth protecting. On a headless build worker the
+  # opposite is true — system.slice IS the workload — so build hosts must
+  # not import this module.
+
+  # Reserve a memory floor for the interactive session. Builds, services,
+  # and containers (in system.slice) can be reclaimed before user.slice
+  # pages are. Soft reservation — user.slice can still use more than this.
+  systemd.slices."user".sliceConfig.MemoryMin = lib.mkDefault "8G";
+
+  # Make systemd-oomd's response to memory pressure aggressive enough to
+  # actually kill runaway builds before the box wedges. The 5s averaging
+  # window means transient spikes don't trigger kills.
+  systemd.oomd.extraConfig.DefaultMemoryPressureDurationSec = lib.mkDefault "5s";
+
+  # Aggressive OOM-kill policy targeted at system.slice only, so the
+  # offender (a runaway build, container, or service) gets killed while
+  # user.slice — games, Chrome, the compositor — is never touched by this
+  # rule. mkForce because upstream nixos oomd.nix sets the limit to "80%"
+  # at mkDefault priority — string options can't merge two equal-priority
+  # defaults, so we have to take precedence. The "kill" mode itself is
+  # already set as a plain assignment by upstream when enableSystemSlice
+  # is true (see common/system.nix), so we don't need to repeat it.
+  systemd.slices."system".sliceConfig.ManagedOOMMemoryPressureLimit = lib.mkForce "70%";
 }

--- a/modules/common/system.nix
+++ b/modules/common/system.nix
@@ -136,10 +136,12 @@
     # Aggressive OOM-kill policy targeted at system.slice only, so the
     # offender (a runaway build, container, or service) gets killed while
     # user.slice — games, Chrome, the compositor — is never touched by
-    # this rule.
+    # this rule. mkForce on the limit because upstream nixos oomd.nix sets
+    # it to "80%" at the same mkDefault priority — string options can't
+    # merge two equal-priority defaults, so we have to take precedence.
     systemd.slices."system".sliceConfig = {
       ManagedOOMMemoryPressure = lib.mkDefault "kill";
-      ManagedOOMMemoryPressureLimit = lib.mkDefault "70%";
+      ManagedOOMMemoryPressureLimit = lib.mkForce "70%";
     };
   };
 }

--- a/modules/common/system.nix
+++ b/modules/common/system.nix
@@ -104,44 +104,29 @@
     # swap-thrash D-state hang seen when a heavy build runs alongside a desktop.
     boot.kernel.sysctl."vm.swappiness" = lib.mkDefault 10;
 
-    # zram-backed compressed swap. Swap-in becomes in-memory zstd
-    # decompression instead of NVMe I/O, eliminating the shmem_swapin_folio
-    # D-state hang that wedged classic-laddie 2026-04-29 / 2026-04-29 (hung_task_timeout
-    # fires after 122s of disk swap-in queueing; zram swap-in is microseconds).
+    # zram-backed compressed swap. Universally beneficial: on desktops it
+    # eliminates the shmem_swapin_folio D-state hang that wedged classic-laddie
+    # 2026-04-29 (hung_task_timeout fires after 122s of NVMe swap-in queueing;
+    # zram swap-in is microseconds). On build workers it lets more concurrent
+    # work fit in RAM via zstd compression.
     zramSwap = {
       enable = lib.mkDefault true;
       algorithm = "zstd";
       memoryPercent = lib.mkDefault 50;
     };
 
-    # Reserve a memory floor for the interactive session. Builds, services,
-    # and containers (in system.slice) can be reclaimed before user.slice
-    # pages are. Soft reservation — user.slice can still use more than this.
-    systemd.slices."user".sliceConfig.MemoryMin = lib.mkDefault "8G";
-
     # Let systemd-oomd kill runaway system services before the kernel's own OOM
     # path leaves user sessions stuck waiting on swap-in. `enable` skips
     # mkDefault on purpose: nixos-wsl ships `oomd.enable = lib.mkDefault false`
     # for older WSL kernels lacking PSI, and two mkDefaults would collide.
     # Modern WSL2 kernels do support oomd, so we override to true everywhere.
+    # Aggressive per-slice tuning (kill thresholds, pressure duration, user
+    # MemoryMin) lives in modules/common/desktop.nix — those are interactive-
+    # session protections that would actively harm a headless build worker
+    # whose workload IS system.slice.
     systemd.oomd = {
       enable = true;
       enableSystemSlice = lib.mkDefault true;
-      # Make systemd-oomd's response to system.slice memory pressure aggressive
-      # enough to actually kill runaway builds before the box wedges. The 5s
-      # averaging window means transient spikes don't trigger kills.
-      extraConfig.DefaultMemoryPressureDurationSec = lib.mkDefault "5s";
-    };
-
-    # Aggressive OOM-kill policy targeted at system.slice only, so the
-    # offender (a runaway build, container, or service) gets killed while
-    # user.slice — games, Chrome, the compositor — is never touched by
-    # this rule. mkForce on the limit because upstream nixos oomd.nix sets
-    # it to "80%" at the same mkDefault priority — string options can't
-    # merge two equal-priority defaults, so we have to take precedence.
-    systemd.slices."system".sliceConfig = {
-      ManagedOOMMemoryPressure = lib.mkDefault "kill";
-      ManagedOOMMemoryPressureLimit = lib.mkForce "70%";
     };
   };
 }

--- a/modules/common/system.nix
+++ b/modules/common/system.nix
@@ -104,6 +104,21 @@
     # swap-thrash D-state hang seen when a heavy build runs alongside a desktop.
     boot.kernel.sysctl."vm.swappiness" = lib.mkDefault 10;
 
+    # zram-backed compressed swap. Swap-in becomes in-memory zstd
+    # decompression instead of NVMe I/O, eliminating the shmem_swapin_folio
+    # D-state hang that wedged classic-laddie 2026-04-29 / 2026-04-29 (hung_task_timeout
+    # fires after 122s of disk swap-in queueing; zram swap-in is microseconds).
+    zramSwap = {
+      enable = lib.mkDefault true;
+      algorithm = "zstd";
+      memoryPercent = lib.mkDefault 50;
+    };
+
+    # Reserve a memory floor for the interactive session. Builds, services,
+    # and containers (in system.slice) can be reclaimed before user.slice
+    # pages are. Soft reservation — user.slice can still use more than this.
+    systemd.slices."user".sliceConfig.MemoryMin = lib.mkDefault "8G";
+
     # Let systemd-oomd kill runaway system services before the kernel's own OOM
     # path leaves user sessions stuck waiting on swap-in. `enable` skips
     # mkDefault on purpose: nixos-wsl ships `oomd.enable = lib.mkDefault false`
@@ -112,6 +127,19 @@
     systemd.oomd = {
       enable = true;
       enableSystemSlice = lib.mkDefault true;
+      # Make systemd-oomd's response to system.slice memory pressure aggressive
+      # enough to actually kill runaway builds before the box wedges. The 5s
+      # averaging window means transient spikes don't trigger kills.
+      extraConfig.DefaultMemoryPressureDurationSec = lib.mkDefault "5s";
+    };
+
+    # Aggressive OOM-kill policy targeted at system.slice only, so the
+    # offender (a runaway build, container, or service) gets killed while
+    # user.slice — games, Chrome, the compositor — is never touched by
+    # this rule.
+    systemd.slices."system".sliceConfig = {
+      ManagedOOMMemoryPressure = lib.mkDefault "kill";
+      ManagedOOMMemoryPressureLimit = lib.mkDefault "70%";
     };
   };
 }


### PR DESCRIPTION
## Summary

Add OS-level memory protection so any nix build — sudo'd from a terminal, kicked off by an agent, or run via `nixos-upgrade.service` — is safe to run alongside an interactive desktop session, regardless of whether it goes through the `cosmo-rebuild` wrapper. The protection is split between two modules along a clear architectural line:

- **`modules/common/system.nix`** (every host): zram swap + base `systemd-oomd` enable. Universal benefit.
- **`modules/common/desktop.nix`** (only hosts with an interactive session — currently classic-laddie, weller, johnny-walker): `user.slice` `MemoryMin` floor, aggressive `system.slice` oomd kill threshold, and 5s pressure-duration tuning.

## The mechanism we're targeting

The classic-laddie wedges aren't OOM kills — they're **swap-in stalls**. When a heavy compile (`rusty-v8`, `ollama-cuda`, `home-assistant`) takes hold of memory, the kernel evicts other resident processes' pages to disk swap. When the compositor / browser / game then tries to use any of those evicted pages, the resulting `shmem_swapin_folio` queues behind the build's own I/O. After 122s of waiting, `hung_task_timeout` fires and the box is unrecoverable. `MemoryMax` alone wouldn't have helped — the build is using the memory it's allowed to use; the problem is that *anyone else's* page faults can't make progress.

## Why universal vs desktop-only

The aggressive oomd config is the load-bearing part of the protection: kill `system.slice` at 70% memory pressure, evaluated over 5s, so a runaway build dies before swap-in queueing wedges the compositor. That's the right policy on a host where `system.slice` is **background work** and `user.slice` is the interactive session worth protecting.

On a headless build worker (klaus-worker-0, future microVMs), the same policy is actively harmful:
- `system.slice` IS the workload — killing it at 70% pressure kills the very builds the host exists to run.
- An 8G `MemoryMin` reservation on an empty `user.slice` is wasted RAM on a 12G microVM (a third of total).
- The 5s aggressive oomd response punishes legitimate compile peaks.

So the protection is scoped to `desktop.nix`, which only desktop hosts import. Server-shaped hosts that import `common/system.nix` (makers-nix WSL) but not `desktop.nix` get the universal pieces (zram, oomd enabled with default 80% / 30s) without the desktop-specific tuning.

zram stays universal: on desktops it eliminates the `shmem_swapin_folio` D-state hang by making swap-in microseconds-fast; on build workers it lets more concurrent work fit in RAM via zstd compression.

## The CI conflict that surfaced this

The first push of this PR failed CI with:

```
error: The option `systemd.slices.system.sliceConfig.ManagedOOMMemoryPressureLimit` has conflicting definition values
```

The conflict source is **upstream nixpkgs**: `nixos/modules/system/boot/systemd/oomd.nix` sets the same option to `lib.mkDefault "80%"` whenever `enableSystemSlice` is true (which our common/system.nix sets). Two `mkDefault` definitions of a string-typed option at equal priority can't merge — the module system aborts.

Resolution:

1. Use `lib.mkForce "70%"` on our value so it wins over upstream's `mkDefault "80%"`. (Done in 44df2f4.)
2. Drop our redundant `ManagedOOMMemoryPressure = lib.mkDefault "kill"` — upstream sets that side as a plain assignment (priority 100, beats our priority-1000 mkDefault), so our override never applied anyway. (Done as part of the split.)

After the split, the `mkForce` lives in `desktop.nix` instead of `system.nix`, so the override is also no longer applied to hosts that import `common/system.nix` but not `desktop.nix` — those hosts now run at upstream's default 80%, which is what we want for build workers.

## Per-knob justification

| Setting | Where | Why |
| --- | --- | --- |
| `zramSwap` (zstd, 50% of RAM) | `system.nix` (universal) | The actual root-cause fix for the swap-in D-state hang. Useful on every host. |
| `boot.kernel.sysctl.\"vm.swappiness\" = 10` | `system.nix` (universal, pre-existing) | Prefer reclaiming page cache over swapping anonymous pages. |
| `systemd.oomd.enable = true; enableSystemSlice = mkDefault true` | `system.nix` (universal, pre-existing) | Lets oomd do its baseline job everywhere. |
| `systemd.slices.\"user\".sliceConfig.MemoryMin = 8G` | `desktop.nix` | Reserves a memory floor for the interactive session. Wasteful on a headless build VM. |
| `systemd.slices.\"system\".sliceConfig.ManagedOOMMemoryPressureLimit = mkForce \"70%\"` | `desktop.nix` | Aggressive kill threshold. On a build server this kills your own workload — opt-out by not importing `desktop.nix`. |
| `systemd.oomd.extraConfig.DefaultMemoryPressureDurationSec = 5s` | `desktop.nix` | 5s averaging window. Same reasoning as above — too aggressive for build workers. |

## Routing

| Host | Imports `common/system.nix`? | Imports `common/desktop.nix`? | Protected? |
| --- | --- | --- | --- |
| classic-laddie | ✓ | ✓ | yes |
| weller | ✓ | ✓ | yes |
| johnny-walker | ✓ | ✓ | yes |
| makers-nix (WSL) | ✓ | ✗ | base only (zram, oomd) |
| klaus-worker-0 (microVM) | ✗ | ✗ | none — uses `modules/klaus-worker/` |

## Notes

- All values use `lib.mkDefault` (or `mkForce` only where the upstream conflict requires it) so hosts can still override per-knob.
- Enables a follow-up: removing the in-prompt 'no local nix tooling' rule from agent dispatch and documenting the new state in `AGENTS.md` once classic-laddie has activated a generation built from this PR.
- Validation: per the no-local-nix-tooling rule, no local `nix build` / `nix flake check` was run against this PR — CI's dry-run is the gate, since the protections this PR adds aren't active on the running system yet.

Run: 20260509-1008-38fc