### PR TITLE
modules/common/desktop.nix: restart xdg portals on failure

### DIFF
--- a/modules/common/desktop.nix
+++ b/modules/common/desktop.nix
@@ -56,4 +56,36 @@
       if config.services.pipewire.jack.enable then "${pipewireJackPath}:${openGLPath}" else openGLPath
     );
   };
+
+  # --- xdg portal restart policy ---
+  # 2026-05-05 incident on classic-laddie: dbus-broker hit its per-UID byte
+  # quota for UID 1000 and force-disconnected several user-session D-Bus
+  # consumers. xdg-desktop-portal and xdg-document-portal exited and stayed
+  # down because upstream nixpkgs ships them without a Restart policy.
+  # Downstream: waybar exited two minutes later, wireplumber's session graph
+  # went stale (Focusrite vanished from PipeWire), and the session limped
+  # along for four days. Auto-restart turns a transient D-Bus blip back into
+  # a transient D-Bus blip instead of a 4-day session degradation.
+  #
+  # StartLimit* caps prevent a genuinely broken portal (misconfig, missing
+  # binary) from looping forever — after 5 failures in 60s systemd gives up
+  # and surfaces the failure for manual triage.
+  systemd.user.services =
+    let
+      restartPolicy = {
+        serviceConfig = {
+          Restart = lib.mkDefault "on-failure";
+          RestartSec = lib.mkDefault "5s";
+        };
+        startLimitBurst = lib.mkDefault 5;
+        startLimitIntervalSec = lib.mkDefault 60;
+      };
+    in
+    {
+      xdg-desktop-portal = restartPolicy;
+      xdg-desktop-portal-gtk = restartPolicy;
+      xdg-desktop-portal-hyprland = restartPolicy;
+      xdg-document-portal = restartPolicy;
+      xdg-permission-store = restartPolicy;
+    };
 }


### PR DESCRIPTION
## Summary

Adds `Restart=on-failure` (with `RestartSec` and `StartLimit*` caps) to the user-session xdg portal services so a transient D-Bus disruption doesn't permanently degrade the desktop session.

Services covered:
- `xdg-desktop-portal`
- `xdg-desktop-portal-gtk`
- `xdg-desktop-portal-hyprland`
- `xdg-document-portal`
- `xdg-permission-store`

All knobs use `lib.mkDefault` so per-host overrides remain possible. The block lives in `modules/common/desktop.nix`, which is already the desktop-scoped module imported by `classic-laddie`, `johnny-walker`, and `weller` (and not by the headless `makers-nix`).

## The 2026-05-05 incident

On classic-laddie at 08:31:24 EDT, dbus-broker hit its per-UID byte quota for UID 1000 and force-disconnected several user-session D-Bus consumers. `xdg-desktop-portal.service` exited and stayed inactive; `xdg-document-portal.service` exited with status 20 and ended up failed. Neither came back, because upstream nixpkgs ships these units without a `Restart` policy.

Downstream of the two portals never returning:

- waybar exited two minutes later (couldn't reach the portal)
- wireplumber's session graph went stale, losing track of ALSA cards — the Focusrite USB interface became invisible to PipeWire even though the kernel still saw it
- The session limped along for four days until the user noticed missing UI elements

This PR addresses the *durability* problem (transient blip → permanent breakage). The proximate trigger — the dbus-broker byte quota — is a separate concern not addressed here.

## Why the StartLimit caps

`Restart=on-failure` alone risks an infinite restart loop if a portal is actually broken (misconfiguration, missing binary, bad upstream change). `StartLimitBurst=5` over `StartLimitIntervalSec=60` means systemd gives up after five failures in a minute and surfaces the failure for manual triage — at which point human intervention is warranted anyway.

## Coordination with #529 and #531

PR #529 (`agent/20260509-1008-38fc`) keeps interactive-session memory protection inside `modules/common/desktop.nix` rather than splitting it into a new module. This change follows the same convention and adds an additional section at the end of the same file. The two PRs touch different regions and should merge cleanly in either order.

PR #531 is the companion ZFS unblock landing separately — trunk is currently red on classic-laddie because ZFS is marked broken against the linux-zen kernel. That's handled by #531 (a `zfs.broken = "warn"` override that preserves the zen kernel) and is out of scope here. CI on classic-laddie will remain red on this PR until #531 merges.

## Validation

No local Nix evaluation was run (per the worktree's no-local-tooling directive — until #529 lands, OS-level memory protection isn't in effect on the build host, so a heavy build could wedge classic-laddie). CI's dry-run is the validation step.

This fits the recurring cosmo theme of durable healing of transient failures.

Run: 20260509-1025-5b02