### PR TITLE
classic-laddie: unblock eval — silence ZFS broken check vs zen kernel

### DIFF
--- a/hosts/classic-laddie/hardware.nix
+++ b/hosts/classic-laddie/hardware.nix
@@ -58,6 +58,15 @@
   # ---------------------------------------------------------------------------
   boot.supportedFilesystems = [ "zfs" ];
 
+  # TEMPORARY UNBLOCK: ZFS 2.4.1 in current nixpkgs is marked broken against
+  # the linux-zen kernel we run (see modules/common/gaming.nix). Both
+  # `pkgs.zfs` (= zfs_2_4) and `pkgs.zfs_unstable` cap at
+  # kernelMaxSupportedMajorMinor = "6.19", and our zen kernel is past that,
+  # so switching packages doesn't help — the broken check fires on both.
+  # Tracked upstream: https://github.com/NixOS/nixpkgs/issues/510485
+  # Remove once nixpkgs ships a ZFS release that supports the running kernel.
+  nixpkgs.config.problems.handlers.zfs.broken = "warn";
+
   # ---------------------------------------------------------------------------
   # USB stability
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
`main` has been red since 2026-05-07 (flake.lock #526). Every CI run since fails at evaluation time on the `classic-laddie` configuration:

```
error: Refusing to evaluate package 'zfs-kernel-2.4.1-7.0.3' in
       /nix/store/.../pkgs/os-specific/linux/zfs/generic.nix:327
       because it has problems:
       zfs.broken = "warn"; # or "ignore"
```

This is the standard nixpkgs ZFS-vs-kernel lag: the latest nixpkgs bumped its default kernel past the highest version that any released ZFS module supports. `classic-laddie` is the only host that enables ZFS (`boot.supportedFilesystems = [ "zfs" ]`, plus `tank/personal` and `tank/media` filesystems) and it pulls in `linux-zen` 7.0.3 via `modules.gaming.enable`. ZFS 2.4.1 caps `kernelMaxSupportedMajorMinor = "6.19"`, so the broken check fires.

## Fix chosen
`nixpkgs.config.problems.handlers.zfs.broken = "warn"` scoped to `classic-laddie/hardware.nix`. This is option (2) — the override the broken-package error itself hints at.

## What I tried first
Option (1), `boot.zfs.package = pkgs.zfs_unstable`. Inspected the locked nixpkgs revision (`549bd84d`): both `pkgs.zfs` (= `zfs_2_4`) and `pkgs.zfs_unstable` declare `kernelMaxSupportedMajorMinor = "6.19"` and pin `version = "2.4.1"`. The broken check fires identically on both packages against a 7.x kernel, so switching the package wouldn't change the eval outcome.

Pinning the kernel back or reverting flake.lock would freeze unrelated updates and is heavier than needed for a temporary unblock.

## Hosts impacted
Only `classic-laddie`. `makers-nix`, `johnny-walker`, and `weller` do not enable ZFS, so the override is scoped to where it's needed.

## Unblock condition
Once nixpkgs picks up an OpenZFS release that supports the running kernel (or we move classic-laddie off `linux-zen`), this override can — and should — be removed. The TODO comment links to the upstream tracking issue: https://github.com/NixOS/nixpkgs/issues/510485

## Context
This unblocks PR #529 (OS-level memory protection) and any future trunk-merging work that has been queued up behind the eval failure.

Run: 20260509-1030-05d3

---

**Cleanup tracked:** #532 (remove this override once nixpkgs/zfs supports our running kernel; references upstream nixpkgs#510485)