### PR TITLE
classic-laddie: pin kernel to stable so ZFS builds

### DIFF
--- a/hosts/classic-laddie/hardware.nix
+++ b/hosts/classic-laddie/hardware.nix
@@ -58,14 +58,20 @@
   # ---------------------------------------------------------------------------
   boot.supportedFilesystems = [ "zfs" ];
 
-  # TEMPORARY UNBLOCK: ZFS 2.4.1 in current nixpkgs is marked broken against
-  # the linux-zen kernel we run (see modules/common/gaming.nix). Both
-  # `pkgs.zfs` (= zfs_2_4) and `pkgs.zfs_unstable` cap at
-  # kernelMaxSupportedMajorMinor = "6.19", and our zen kernel is past that,
-  # so switching packages doesn't help — the broken check fires on both.
-  # Tracked upstream: https://github.com/NixOS/nixpkgs/issues/510485
-  # Remove once nixpkgs ships a ZFS release that supports the running kernel.
-  nixpkgs.config.problems.handlers.zfs.broken = "warn";
+  # ZFS upstream's kernelMaxSupportedMajorMinor = "6.19"; the linux-zen
+  # kernel pulled in by recent flake.lock updates (7.0.3 as of #528) is past
+  # that, so ZFS 2.4.1 won't compile (configure-time "Cannot build against
+  # kernel version 7.0.3-zen1"). Pin to stable until nixpkgs ships a ZFS
+  # release with a higher kernel cap. PR #531 tried setting the broken flag
+  # to "warn" instead — that silenced eval but didn't fix the actual build,
+  # since CI dry-run doesn't compile kmods.
+  #
+  # sched-ext is upstream in 6.12+, so services.scx still works on stable.
+  #
+  # mkOverride 60 wins against the default-priority assignment in
+  # modules/common/gaming.nix while still losing to the mkForce inside
+  # the stable-kernel specialisation, preserving that fallback.
+  boot.kernelPackages = lib.mkOverride 60 pkgs.linuxPackages;
 
   # ---------------------------------------------------------------------------
   # USB stability


### PR DESCRIPTION
## Problem

PR #531 added `nixpkgs.config.problems.handlers.zfs.broken = \"warn\"` to silence the ZFS broken check. CI passed because `nix build --dry-run` only evaluates — it doesn't compile kernel modules. On a real local rebuild today, the build fails:

```
configure: error:
   *** Cannot build against kernel version 7.0.3-zen1.
   *** The maximum supported kernel version is 6.19.
```

So the `broken` flag was actually correct — ZFS 2.4.1 literally cannot compile against the linux-zen 7.0.3 kernel pulled in by recent flake.lock updates (#528). The eval-time silence trick let evaluation succeed but the kmod build fails for real. classic-laddie boots from a ZFS root, so the kernel must have a working ZFS module.

## Why CI didn't catch this

The `build-nixos` job runs evaluation against the flake (effectively a dry-run path). Kernel module compilation only happens during a full system build / activation. So an eval-time-only silencing trick will always look green in CI even when the resulting system can't actually build.

This PR doesn't fix that gap — it just stops relying on eval-time-only validation for a build-time problem.

## Fix

Replace #531's eval-time workaround with an actual kernel pin in `hosts/classic-laddie/hardware.nix`:

```nix
boot.kernelPackages = lib.mkOverride 60 pkgs.linuxPackages;
```

Priority math:

- `modules/common/gaming.nix` assigns `boot.kernelPackages = pkgs.linuxPackages_zen` at default priority (100).
- The `stable-kernel` specialisation inside `gaming.nix` uses `lib.mkForce` (priority 50) to fall back to `pkgs.linuxPackages`.
- `lib.mkOverride 60` wins against the default-priority zen assignment but still loses to the `mkForce` inside the specialisation — the existing stable-kernel fallback continues to work as designed.

`pkgs.linuxPackages` is the proven-working stable target: it's the same attribute the `stable-kernel` specialisation already uses.

## sched-ext / services.scx

sched-ext was upstreamed in kernel 6.12, so the BPF scheduler used by `services.scx` continues to work on stable. No functional regression in gaming.nix's userspace.

## Tracking issue

Issue #532 was opened to track removal of #531's `broken=\"warn\"` override. After this PR lands, I'll comment there explaining the override was insufficient and either close it or repurpose it to track 'remove kernel pin once nixpkgs ZFS supports zen 7.x.'

## Verification

- CI eval will pass — but as noted above, that's not the gate that matters for this class of change.
- Real verification is a successful `nixos-rebuild switch` on classic-laddie.

Run: 20260509-1415-69f7