### PR TITLE
nix: silence four classic-laddie rebuild eval warnings

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -122,11 +122,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775409789,
-        "narHash": "sha256-teH1aIFAqCdL4JWBEM+UVQNAi6AhrHeYFVselzsL6+A=",
+        "lastModified": 1779149081,
+        "narHash": "sha256-jEvQ9KRZhO94205r15XBHlC73KzSmp1Sue2SwkJbNn4=",
         "owner": "patflynn",
         "repo": "github-relay",
-        "rev": "12f4008ea747159a067a7391e9e613c744042d64",
+        "rev": "7d019e9dd9c3512853f45ebe98bdf89cdc2b8aff",
         "type": "github"
       },
       "original": {

--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -100,6 +100,7 @@
 
   wayland.windowManager.hyprland = {
     enable = true;
+    configType = "hyprlang";
     settings = {
       # --- Monitors ---
       # Auto-detect monitors with preferred resolution

--- a/hosts/classic-laddie/default.nix
+++ b/hosts/classic-laddie/default.nix
@@ -17,24 +17,7 @@
     ../../modules/common/ddcci.nix
     ../../modules/media-server/default.nix
     inputs.reel-life.nixosModules.default
-    # Wrap github-relay's nixos module to shadow `pkgs.system` (deprecated
-    # alias that prints "renamed to stdenv.hostPlatform.system" on every
-    # eval). The upstream module reads `pkgs.system` at module-level let-
-    # binding time, so we substitute a pkgs that has `system` resolved to
-    # its non-aliased value before the upstream module sees it. Drop this
-    # wrapper once patflynn/github-relay fixes module.nix to use
-    # `pkgs.stdenv.hostPlatform.system`.
-    (
-      moduleArgs@{ pkgs, ... }:
-      inputs.github-relay.nixosModules.default (
-        moduleArgs
-        // {
-          pkgs = pkgs // {
-            system = pkgs.stdenv.hostPlatform.system;
-          };
-        }
-      )
-    )
+    inputs.github-relay.nixosModules.default
   ];
 
   cosmo.user.default = "patrick";

--- a/hosts/classic-laddie/default.nix
+++ b/hosts/classic-laddie/default.nix
@@ -17,7 +17,24 @@
     ../../modules/common/ddcci.nix
     ../../modules/media-server/default.nix
     inputs.reel-life.nixosModules.default
-    inputs.github-relay.nixosModules.default
+    # Wrap github-relay's nixos module to shadow `pkgs.system` (deprecated
+    # alias that prints "renamed to stdenv.hostPlatform.system" on every
+    # eval). The upstream module reads `pkgs.system` at module-level let-
+    # binding time, so we substitute a pkgs that has `system` resolved to
+    # its non-aliased value before the upstream module sees it. Drop this
+    # wrapper once patflynn/github-relay fixes module.nix to use
+    # `pkgs.stdenv.hostPlatform.system`.
+    (
+      moduleArgs@{ pkgs, ... }:
+      inputs.github-relay.nixosModules.default (
+        moduleArgs
+        // {
+          pkgs = pkgs // {
+            system = pkgs.stdenv.hostPlatform.system;
+          };
+        }
+      )
+    )
   ];
 
   cosmo.user.default = "patrick";

--- a/hosts/classic-laddie/hardware.nix
+++ b/hosts/classic-laddie/hardware.nix
@@ -58,6 +58,10 @@
   # ---------------------------------------------------------------------------
   boot.supportedFilesystems = [ "zfs" ];
 
+  # Explicitly opt into the safer 26.11+ default. Forced root pool import
+  # masks real problems (split-brain, missed exports) and risks data loss.
+  boot.zfs.forceImportRoot = false;
+
   # ZFS upstream's kernelMaxSupportedMajorMinor = "6.19"; the linux-zen
   # kernel pulled in by recent flake.lock updates (7.0.3 as of #528) is past
   # that, so ZFS 2.4.1 won't compile (configure-time "Cannot build against

--- a/modules/common/desktop.nix
+++ b/modules/common/desktop.nix
@@ -105,7 +105,7 @@
   # Make systemd-oomd's response to memory pressure aggressive enough to
   # actually kill runaway builds before the box wedges. The 5s averaging
   # window means transient spikes don't trigger kills.
-  systemd.oomd.extraConfig.DefaultMemoryPressureDurationSec = lib.mkDefault "5s";
+  systemd.oomd.settings.OOM.DefaultMemoryPressureDurationSec = lib.mkDefault "5s";
 
   # Aggressive OOM-kill policy targeted at system.slice only, so the
   # offender (a runaway build, container, or service) gets killed while


### PR DESCRIPTION
## Summary

Cleans up four NixOS evaluation warnings that fired on every `rebuild` of `classic-laddie` (each appeared twice — once for the nixos eval, once for the home-manager eval). Verified gone via `nixos-rebuild build --flake .#classic-laddie 2>&1 | grep 'evaluation warning'` (now empty).

| # | Warning | Fix |
|---|---------|-----|
| 1 | `wayland.windowManager.hyprland.configType` default changing from `"hyprlang"` to `"lua"` (we got the legacy default because `home.stateVersion` < `"26.05"`) | `home/hyprland.nix`: explicitly pin `configType = "hyprlang"` inside the existing `wayland.windowManager.hyprland` block to preserve current behavior |
| 2 | `'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'` | Fixed upstream in `patflynn/github-relay#5` (merged). `flake.lock` bumped to pick up the fix, and the local wrapper in `hosts/classic-laddie/default.nix` that was added earlier in this PR has been dropped — the bare `inputs.github-relay.nixosModules.default` import is back |
| 3 | `systemd.oomd.extraConfig` renamed to `systemd.oomd.settings.OOM` | `modules/common/desktop.nix:108`: renamed `systemd.oomd.extraConfig.DefaultMemoryPressureDurationSec` → `systemd.oomd.settings.OOM.DefaultMemoryPressureDurationSec`. Surrounding comment left intact |
| 4 | `boot.zfs.forceImportRoot` flipping from `true` → `false` in 26.11 | `hosts/classic-laddie/hardware.nix`: explicitly set `boot.zfs.forceImportRoot = false;` (the safer new default — pool here is a stable single-disk root, no reason to force) with a short rationale comment |

`home.stateVersion` / `system.stateVersion` left untouched as instructed.

No other evaluation warnings remain after the fixes.

## Test plan

- [x] `nixos-rebuild build --flake .#classic-laddie` succeeds
- [x] `nixos-rebuild build --flake .#classic-laddie 2>&1 | grep 'evaluation warning'` returns no matches (both copies of all four warnings are gone)
- [x] `klaus _pre-review` reports no issues

Run: 20260518-1817-ce168fce