### PR TITLE
klaus: enable poll fallback on work hosts

### DIFF
--- a/home/dev.nix
+++ b/home/dev.nix
@@ -15,6 +15,17 @@
     description = "Whether to install the public gemini-cli package.";
   };
 
+  options.cosmo.klaus.pollFallback = lib.mkOption {
+    type = lib.types.bool;
+    default = false;
+    description = ''
+      Whether klaus should fall back to GitHub API polling for pipeline events.
+      Default false relies on the Tailscale webhook relay (classic-laddie).
+      Set true on hosts that cannot reach the relay (e.g. corp machines with no
+      Tailscale), otherwise the pipeline receives no events.
+    '';
+  };
+
   config = {
     # Development Tools
     home.packages =
@@ -62,7 +73,7 @@
       webhook = {
         port = 9800;
         path = "/webhook/github";
-        poll_fallback = false;
+        poll_fallback = config.cosmo.klaus.pollFallback;
         relay_url = "https://classic-laddie.coin-inconnu.ts.net";
         secret_file = "/run/agenix/github-webhook-secret";
       };

--- a/home/identities/work.nix
+++ b/home/identities/work.nix
@@ -2,6 +2,10 @@
 {
   cosmo.gemini.enable = false;
 
+  # Corp hosts (bushmills, work crostini) can't reach the Tailscale webhook
+  # relay, so klaus must poll GitHub for pipeline events instead.
+  cosmo.klaus.pollFallback = true;
+
   programs.zsh.initContent = lib.mkBefore ''
     # Source corporate configuration if it exists (e.g. from Piper/CitC)
     if [ -f "$HOME/.corp.zsh" ]; then


### PR DESCRIPTION
## Problem

Corp machines (bushmills, work crostini) can't reach the Tailscale webhook relay
(`classic-laddie.coin-inconnu.ts.net`) — there's no Tailscale on these hosts and the
relay is unreachable from the corp network. With `poll_fallback = false`, the klaus
pipeline controller therefore receives **no** events on these machines: no CI
monitoring, no auto fix-agent dispatch, no auto-merge.

## Change

- Add a `cosmo.klaus.pollFallback` option in `home/dev.nix` (default `false`, preserving
  the webhook-relay behavior on personal hosts / classic-laddie).
- Wire it into the generated `~/.klaus/config.json` (`poll_fallback = config.cosmo.klaus.pollFallback`).
- Enable it in the work identity (`home/identities/work.nix`), so bushmills and work
  crostini fall back to GitHub API polling for pipeline events.

Follows the existing `cosmo.gemini.enable` option pattern (declared in `dev.nix`, set per
identity).

## Verification

```
nix eval --raw .#homeConfigurations."paflynn@bushmills"...poll_fallback  => true
nix eval --raw .#homeConfigurations.personal...poll_fallback             => false
```

Note: polling runs inside the pipeline controller (`klaus dashboard`), which must be
running on the host for events to flow.