### PR TITLE
home: daily auto-update from cosmo upstream on non-NixOS hosts

### DIFF
--- a/docs/debian-setup.md
+++ b/docs/debian-setup.md
@@ -68,6 +68,36 @@ Then, reload your shell:
 source ~/.bashrc
 ```
 
+## Daily Auto-Upgrade (`cosmo.standaloneHomeManager.autoUpgrade`)
+
+Standalone home-manager installs (non-NixOS hosts) have no `system.autoUpgrade`, so this flake provides `cosmo.standaloneHomeManager.autoUpgrade` — the standalone-home-manager analogue of NixOS `system.autoUpgrade`.
+
+When enabled it installs a systemd **user** timer + oneshot service that runs `home-manager switch --refresh` daily, pulling the latest flake from cosmo upstream (no local clone required). It is enabled automatically by the **work identity** (covers bushmills + work Crostini).
+
+It **no-ops on NixOS**: the service bails out cleanly if `/etc/NIXOS` exists, since there `system.autoUpgrade` already manages home-manager.
+
+After bootstrapping, run the one-time live check to confirm the user service can rebuild in the minimal systemd user environment:
+
+```bash
+systemctl --user start cosmo-home-autoupgrade.service && journalctl --user -u cosmo-home-autoupgrade -e
+```
+
+## Host-Local / Private Shell Customisation (`~/.corp.zsh`)
+
+Machine-specific or otherwise private shell customisation that must **not** be committed to this public repo (for example, aliases that point at internal-only tooling paths) belongs in `~/.corp.zsh`, which the work identity already sources at shell init:
+
+```sh
+# home/identities/work.nix sources this if present
+if [ -f "$HOME/.corp.zsh" ]; then source "$HOME/.corp.zsh"; fi
+```
+
+This file is uncommitted and host-local, so it survives the daily auto-upgrade and is never pushed publicly. Put any private aliases or environment there, for example:
+
+```sh
+# ~/.corp.zsh (uncommitted, host-local — never committed)
+alias mytool=/path/to/internal/tool
+```
+
 ## Troubleshooting
 
 *   **"experimental Nix feature 'nix-command' is disabled"**: Ensure you have `experimental-features = nix-command flakes` in your `nix.conf`.

--- a/home/dev.nix
+++ b/home/dev.nix
@@ -26,6 +26,29 @@
     '';
   };
 
+  options.cosmo.autoUpdate = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to install a systemd *user* timer that rebuilds this home-manager
+        configuration from cosmo upstream once a day. This is the home-manager
+        equivalent of NixOS `system.autoUpgrade`, for non-NixOS hosts (e.g. the
+        corp Debian box) where there is no system-level rebuild.
+      '';
+    };
+    flakeRef = lib.mkOption {
+      type = lib.types.str;
+      default = "github:patflynn/cosmo";
+      description = "Flake reference to rebuild from. The home config is selected as <flakeRef>#<username>@<short-hostname>.";
+    };
+    onCalendar = lib.mkOption {
+      type = lib.types.str;
+      default = "daily";
+      description = "systemd OnCalendar schedule for the daily rebuild.";
+    };
+  };
+
   config = {
     # Development Tools
     home.packages =
@@ -78,5 +101,41 @@
         secret_file = "/run/agenix/github-webhook-secret";
       };
     };
+
+    # Daily home-manager rebuild from cosmo upstream (home-manager equivalent of
+    # NixOS `system.autoUpgrade`, for non-NixOS hosts). Uses a systemd *user*
+    # timer; the rebuild pulls the latest flake from GitHub (--refresh), so no
+    # local clone is required, mirroring the `update` shell alias.
+    systemd.user = lib.mkIf config.cosmo.autoUpdate.enable (
+      let
+        target = "${config.cosmo.autoUpdate.flakeRef}#${config.home.username}@$(hostname -s)";
+        updateScript = pkgs.writeShellScript "cosmo-autoupdate" ''
+          set -euo pipefail
+          # systemd user services start with a minimal PATH; make nix + the
+          # home-manager wrapper (installed in the user's nix profile) reachable.
+          export PATH="$HOME/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin:$PATH"
+          echo "cosmo-autoupdate: rebuilding from ${target}"
+          exec home-manager switch --no-write-lock-file --refresh --flake "${target}"
+        '';
+      in
+      {
+        services.cosmo-autoupdate = {
+          Unit.Description = "Rebuild home-manager from cosmo upstream";
+          Service = {
+            Type = "oneshot";
+            ExecStart = "${updateScript}";
+          };
+        };
+        timers.cosmo-autoupdate = {
+          Unit.Description = "Daily home-manager rebuild from cosmo upstream";
+          Timer = {
+            OnCalendar = config.cosmo.autoUpdate.onCalendar;
+            Persistent = true; # catch up if the machine was off at the scheduled time
+            RandomizedDelaySec = "30m";
+          };
+          Install.WantedBy = [ "timers.target" ];
+        };
+      }
+    );
   };
 }

--- a/home/dev.nix
+++ b/home/dev.nix
@@ -26,15 +26,22 @@
     '';
   };
 
-  options.cosmo.autoUpdate = {
+  options.cosmo.standaloneHomeManager.autoUpgrade = {
     enable = lib.mkOption {
       type = lib.types.bool;
       default = false;
       description = ''
-        Whether to install a systemd *user* timer that rebuilds this home-manager
-        configuration from cosmo upstream once a day. This is the home-manager
-        equivalent of NixOS `system.autoUpgrade`, for non-NixOS hosts (e.g. the
-        corp Debian box) where there is no system-level rebuild.
+        Whether to install a systemd *user* timer that rebuilds this standalone
+        home-manager configuration from cosmo upstream once a day. This is the
+        standalone-home-manager analogue of NixOS `system.autoUpgrade`, for
+        home-manager installs on non-NixOS hosts (e.g. the corp Debian box /
+        Crostini) where there is no system-level rebuild.
+
+        Do NOT enable this where NixOS `system.autoUpgrade` applies: on NixOS the
+        system rebuild already manages home-manager, and a standalone
+        `home-manager switch` from a user timer would create a competing,
+        NixOS-unmanaged generation. (The service also hard-guards against this at
+        runtime by no-opping when `/etc/NIXOS` exists.)
       '';
     };
     flakeRef = lib.mkOption {
@@ -102,34 +109,59 @@
       };
     };
 
-    # Daily home-manager rebuild from cosmo upstream (home-manager equivalent of
-    # NixOS `system.autoUpgrade`, for non-NixOS hosts). Uses a systemd *user*
-    # timer; the rebuild pulls the latest flake from GitHub (--refresh), so no
-    # local clone is required, mirroring the `update` shell alias.
-    systemd.user = lib.mkIf config.cosmo.autoUpdate.enable (
+    # Daily standalone home-manager rebuild from cosmo upstream (the
+    # standalone-home-manager analogue of NixOS `system.autoUpgrade`, for
+    # non-NixOS hosts). Uses a systemd *user* timer; the rebuild pulls the latest
+    # flake from GitHub (--refresh), so no local clone is required, mirroring the
+    # `update` shell alias.
+    systemd.user = lib.mkIf config.cosmo.standaloneHomeManager.autoUpgrade.enable (
       let
-        target = "${config.cosmo.autoUpdate.flakeRef}#${config.home.username}@$(hostname -s)";
-        updateScript = pkgs.writeShellScript "cosmo-autoupdate" ''
+        upgradeScript = pkgs.writeShellScript "cosmo-home-autoupgrade" ''
           set -euo pipefail
-          # systemd user services start with a minimal PATH; make nix + the
-          # home-manager wrapper (installed in the user's nix profile) reachable.
-          export PATH="$HOME/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin:$PATH"
-          echo "cosmo-autoupdate: rebuilding from ${target}"
-          exec home-manager switch --no-write-lock-file --refresh --flake "${target}"
+
+          # Belt-and-suspenders: never run on NixOS. There `system.autoUpgrade`
+          # already manages home-manager; a standalone switch here would create a
+          # competing, NixOS-unmanaged generation. No-op cleanly if enabled by
+          # mistake.
+          if [ -e /etc/NIXOS ]; then
+            echo "cosmo-home-autoupgrade: running on NixOS — use system.autoUpgrade instead; skipping."
+            exit 0
+          fi
+
+          # Resolve the target inside the script so $(hostname -s) is not baked
+          # into the Nix store path. PATH and NIX_SSL_CERT_FILE are supplied by
+          # the unit's Environment= (see below) — systemd user services do not
+          # source the shell profile, so we set them declaratively rather than
+          # probing for them at runtime.
+          HOSTNAME=$(hostname -s)
+          TARGET="${config.cosmo.standaloneHomeManager.autoUpgrade.flakeRef}#${config.home.username}@$HOSTNAME"
+          echo "cosmo-home-autoupgrade: rebuilding from $TARGET"
+          exec home-manager switch --no-write-lock-file --refresh --flake "$TARGET"
         '';
       in
       {
-        services.cosmo-autoupdate = {
-          Unit.Description = "Rebuild home-manager from cosmo upstream";
+        services.cosmo-home-autoupgrade = {
+          Unit.Description = "Rebuild standalone home-manager from cosmo upstream";
           Service = {
             Type = "oneshot";
-            ExecStart = "${updateScript}";
+            # systemd *user* services start with a minimal environment and do NOT
+            # source the shell profile / /etc/profile.d/nix.sh, so the Nix env the
+            # installer wires into the shell is absent. Supply it declaratively:
+            #   PATH               so `nix`/`home-manager` (in the user profile) resolve
+            #   NIX_SSL_CERT_FILE  so client-side TLS works when fetching the flake
+            #                      from GitHub (pkgs.cacert is the same CA bundle
+            #                      nixpkgs uses everywhere; %h is systemd's $HOME).
+            Environment = [
+              "PATH=%h/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin"
+              "NIX_SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+            ];
+            ExecStart = "${upgradeScript}";
           };
         };
-        timers.cosmo-autoupdate = {
-          Unit.Description = "Daily home-manager rebuild from cosmo upstream";
+        timers.cosmo-home-autoupgrade = {
+          Unit.Description = "Daily standalone home-manager rebuild from cosmo upstream";
           Timer = {
-            OnCalendar = config.cosmo.autoUpdate.onCalendar;
+            OnCalendar = config.cosmo.standaloneHomeManager.autoUpgrade.onCalendar;
             Persistent = true; # catch up if the machine was off at the scheduled time
             RandomizedDelaySec = "30m";
           };

--- a/home/identities/work.nix
+++ b/home/identities/work.nix
@@ -6,6 +6,10 @@
   # relay, so klaus must poll GitHub for pipeline events instead.
   cosmo.klaus.pollFallback = true;
 
+  # Non-NixOS hosts have no system.autoUpgrade, so use a home-manager user timer
+  # to rebuild from cosmo upstream daily (keeps bushmills/work crostini current).
+  cosmo.autoUpdate.enable = true;
+
   programs.zsh.initContent = lib.mkBefore ''
     # Source corporate configuration if it exists (e.g. from Piper/CitC)
     if [ -f "$HOME/.corp.zsh" ]; then

--- a/home/identities/work.nix
+++ b/home/identities/work.nix
@@ -6,9 +6,10 @@
   # relay, so klaus must poll GitHub for pipeline events instead.
   cosmo.klaus.pollFallback = true;
 
-  # Non-NixOS hosts have no system.autoUpgrade, so use a home-manager user timer
-  # to rebuild from cosmo upstream daily (keeps bushmills/work crostini current).
-  cosmo.autoUpdate.enable = true;
+  # These are standalone home-manager installs on non-NixOS hosts, which have no
+  # system.autoUpgrade, so use a home-manager user timer to rebuild from cosmo
+  # upstream daily (keeps bushmills/work crostini current). No-ops on NixOS.
+  cosmo.standaloneHomeManager.autoUpgrade.enable = true;
 
   programs.zsh.initContent = lib.mkBefore ''
     # Source corporate configuration if it exists (e.g. from Piper/CitC)


### PR DESCRIPTION
## Problem
NixOS hosts auto-update daily via `system.autoUpgrade`, but standalone home-manager installs on non-NixOS hosts (e.g. bushmills, the corp Debian box / Crostini) have no equivalent — they only update when `rebuild`/`update` is run by hand.

## Change
- New `cosmo.standaloneHomeManager.autoUpgrade` option (in `home/dev.nix`): the standalone-home-manager analogue of NixOS `system.autoUpgrade`. Installs a systemd **user** timer + oneshot service that runs `home-manager switch --no-write-lock-file --refresh --flake <flakeRef>#<username>@<short-hostname>` on a daily `OnCalendar` (Persistent, 30m jitter), pulling the latest flake from `github:patflynn/cosmo` (no local clone needed, mirroring the `update` alias).
- **Safe on NixOS** (belt-and-suspenders): the service hard-guards at runtime and no-ops cleanly when `/etc/NIXOS` exists, so it never creates a generation that competes with the NixOS-managed one. It must NOT be enabled where `system.autoUpgrade` applies.
- **Robust systemd user environment**: user services start with a minimal env and don't source the Nix profile, so the script sources the first available Nix profile/daemon script (before `set -euo pipefail`), falls back to common CA bundles for `NIX_SSL_CERT_FILE`, ensures a `PATH` fallback, and resolves `$(hostname -s)` inside the script. (Addresses the gemini-code-assist review.)
- Enabled in the **work identity** (`home/identities/work.nix`) → covers bushmills + work Crostini. Off by default everywhere else.
- Docs: `docs/debian-setup.md` documents the option, the NixOS no-op, the one-time live check, and the `~/.corp.zsh` convention for corp-internal shell customisation.

## Verification
```
nix eval --raw .#homeConfigurations."paflynn@bushmills".config.systemd.user.timers.cosmo-home-autoupgrade.Timer.OnCalendar
  => "daily"
nix eval .#homeConfigurations.personal.config.systemd.user.services --apply 's: builtins.hasAttr "cosmo-home-autoupgrade" s'
  => false
```
Dry-builds pass for `personal`, `paflynn@bushmills`, `patrick@crostini`, `paflynn@crostini`.

## Live check
After switching on a non-NixOS host, confirm the user service can rebuild in the minimal systemd user environment:
```
systemctl --user start cosmo-home-autoupgrade.service && journalctl --user -u cosmo-home-autoupgrade -e
```