### PR TITLE
hosts: pin nvidia_uvm in boot.kernelModules on RTX 4090 hosts

### DIFF
--- a/hosts/classic-laddie/hardware.nix
+++ b/hosts/classic-laddie/hardware.nix
@@ -49,6 +49,14 @@
     "nvidia_drm"
   ];
 
+  # Load the CUDA/compute module (nvidia_uvm) explicitly at boot. It only
+  # matters at runtime, so boot.kernelModules (not initrd) is correct. We had
+  # been relying on udev / nvidia-modprobe to auto-load it on demand, but that
+  # path regressed after the 595.80 driver bump (udev failed to mknod
+  # /dev/nvidia*), so nvidia_uvm never loaded and CUDA silently broke while the
+  # display modules above kept working.
+  boot.kernelModules = [ "nvidia_uvm" ];
+
   # Allow qemu-libvirtd to access the GPU
   users.groups.video.members = [ "qemu-libvirtd" ];
   users.groups.render.members = [ "qemu-libvirtd" ];

--- a/hosts/weller/hardware.nix
+++ b/hosts/weller/hardware.nix
@@ -21,7 +21,10 @@
     "usbhid"
     "sd_mod"
   ];
-  boot.kernelModules = [ "kvm-amd" ];
+  boot.kernelModules = [
+    "kvm-amd"
+    "nvidia_uvm" # CUDA/compute module; pin at boot so it doesn't rely on udev auto-load
+  ];
   hardware.cpu.amd.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
 


### PR DESCRIPTION
## Problem

On host `classic-laddie` (RTX 4090), CUDA compute silently broke after an automated `flake.lock` update bumped the NVIDIA driver 595.71.05 -> 595.80. Root-cause chain confirmed from journald:

- The driver's **display** modules (`nvidia`, `nvidia_modeset`, `nvidia_drm`) load fine — they are force-loaded in initrd — so the desktop and `nvidia-smi` keep working.
- `nvidia_uvm` (the Unified Virtual Memory module CUDA requires) was relying on udev / `nvidia-modprobe` to load on demand and create `/dev/nvidia-uvm`. The new driver revision regressed that path (udev logged `mknod /dev/nvidiactl ... failed with exit code 1`), so `nvidia_uvm` never loaded and `/dev/nvidia-uvm` never appeared.
- With no usable CUDA device, Ollama fell back to CPU (`library=cpu`, `total_vram="0 B"`) and loaded a 20GB model into 31GB of system RAM, exhausting RAM during the tensor repack step and hard-locking the machine.

## Fix

Pin `nvidia_uvm` in `boot.kernelModules` on both RTX 4090 hosts so the compute module loads deterministically at boot instead of depending on the flaky udev auto-load. `boot.kernelModules` (not initrd) is correct — UVM is only needed at runtime for CUDA, not for the early-boot framebuffer.

- `hosts/classic-laddie/hardware.nix`: add `boot.kernelModules = [ "nvidia_uvm" ];`
- `hosts/weller/hardware.nix`: append `"nvidia_uvm"` to the existing `boot.kernelModules` list (the other 4090 host, same latent gap)

The initrd display-module block, driver package selection, and everything else are untouched.

## Verification

- `nixfmt --check` on both files: passed
- `nix build --no-link .#nixosConfigurations.classic-laddie.config.system.build.toplevel --dry-run`: evaluated, resolved derivations, no errors
- `nix build --no-link .#nixosConfigurations.weller.config.system.build.toplevel --dry-run`: evaluated, resolved derivations, no errors

Run: 20260613-1405-9ff7e689