### PR TITLE
classic-laddie: add qwen3 + qwen2.5-coder models and cap Ollama context

### DIFF
--- a/hosts/classic-laddie/default.nix
+++ b/hosts/classic-laddie/default.nix
@@ -218,7 +218,19 @@
   services.ollama = {
     enable = true;
     package = pkgs.ollama-cuda;
-    loadModels = [ "gemma4:26b" ];
+    loadModels = [
+      "gemma4:26b"
+      "qwen3:32b"
+      "qwen2.5-coder:32b"
+    ];
+    environmentVariables = {
+      # Cap the default context so the 32B dense models (qwen3, qwen2.5-coder)
+      # stay fully resident in the 4090's 24GB VRAM. At Ollama's auto-selected
+      # 32K context the KV cache overflowed VRAM and spilled ~23% of the model
+      # to the CPU, badly hurting throughput. 8192 is a safe default for every
+      # model here; override per request with options.num_ctx when more is needed.
+      OLLAMA_CONTEXT_LENGTH = "8192";
+    };
   };
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Extends the declarative Ollama config on `classic-laddie` (RTX 4090, 24GB VRAM):

- Adds `qwen3:32b` and `qwen2.5-coder:32b` to the declaratively-managed `loadModels`, alongside the existing `gemma4:26b`.
- Pins `OLLAMA_CONTEXT_LENGTH=8192` via `services.ollama.environmentVariables`.

## Why the context cap

At Ollama's auto-selected 32K context, the KV cache for a ~20GB 32B model overflows the 4090's 24GB VRAM and spills ~23% of the model onto the CPU, which tanks throughput (and previously contributed to an out-of-RAM hard lock). Capping the default context at 8192 keeps the 32B dense models fully GPU-resident. It's a safe default for every model here; callers that need more can override per request with `options.num_ctx`.

## Verification

- `nix develop -c nixfmt --check hosts/classic-laddie/default.nix` → passed (exit 0)
- `nix build --no-link .#nixosConfigurations.classic-laddie.config.system.build.toplevel --dry-run` → passed (exit 0); derivation evaluates and dependencies resolve, confirming `services.ollama.environmentVariables` is the correct option on this nixpkgs revision.
- `klaus _pre-review` → no issues found.

Diff is limited to the `services.ollama` block.

Run: 20260613-1427-70ad6c4a