### PR TITLE
feat(home): add native Antigravity IDE

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -147,6 +147,9 @@
                     ./home/identities/personal.nix
                     ./home/monitor-input.nix
                   ];
+                  # Native (non-FHS) Antigravity IDE; unfree, allowed on this
+                  # GPU host (hardware.nix sets nixpkgs.config.allowUnfree).
+                  cosmo.antigravity.enable = true;
                   # Lock screen immediately on session start (auto-login is enabled)
                   wayland.windowManager.hyprland.settings.exec-once = [ "hyprlock" ];
                 };

--- a/home/dev.nix
+++ b/home/dev.nix
@@ -9,12 +9,6 @@
 {
   imports = [ ./common.nix ];
 
-  options.cosmo.gemini.enable = lib.mkOption {
-    type = lib.types.bool;
-    default = true;
-    description = "Whether to install the public gemini-cli package.";
-  };
-
   options.cosmo.antigravity.enable = lib.mkOption {
     type = lib.types.bool;
     default = false;
@@ -92,7 +86,6 @@
         # Agent orchestration
         inputs.klaus.packages."${pkgs.stdenv.hostPlatform.system}".default
       ]
-      ++ lib.optional config.cosmo.gemini.enable pkgs.gemini-cli
       ++ lib.optional config.cosmo.antigravity.enable pkgs.antigravity;
 
     programs.zsh.shellAliases = {

--- a/home/dev.nix
+++ b/home/dev.nix
@@ -15,6 +15,16 @@
     description = "Whether to install the public gemini-cli package.";
   };
 
+  options.cosmo.antigravity.enable = lib.mkOption {
+    type = lib.types.bool;
+    default = false;
+    description = ''
+      Whether to install the native (non-FHS) Antigravity IDE
+      (pkgs.antigravity, autoPatchelf-based). Unfree; requires
+      nixpkgs.config.allowUnfree on the host.
+    '';
+  };
+
   options.cosmo.klaus.pollFallback = lib.mkOption {
     type = lib.types.bool;
     default = false;
@@ -71,9 +81,6 @@
         gcc
         openssl
 
-        # IDEs
-        antigravity
-
         # CLIs
         claude-code # Anthropic's CLI
         github-cli # GitHub CLI (gh)
@@ -85,7 +92,8 @@
         # Agent orchestration
         inputs.klaus.packages."${pkgs.stdenv.hostPlatform.system}".default
       ]
-      ++ lib.optional config.cosmo.gemini.enable pkgs.gemini-cli;
+      ++ lib.optional config.cosmo.gemini.enable pkgs.gemini-cli
+      ++ lib.optional config.cosmo.antigravity.enable pkgs.antigravity;
 
     programs.zsh.shellAliases = {
       rebuild = "if [ -e /etc/NIXOS ]; then sudo nixos-rebuild switch --flake .; else nix run home-manager -- switch --flake .; fi";

--- a/home/identities/work.nix
+++ b/home/identities/work.nix
@@ -1,7 +1,5 @@
 { lib, ... }:
 {
-  cosmo.gemini.enable = false;
-
   # Corp hosts (bushmills, work crostini) can't reach the Tailscale webhook
   # relay, so klaus must poll GitHub for pipeline events instead.
   cosmo.klaus.pollFallback = true;


### PR DESCRIPTION
Adds the native (autoPatchelf-based, like nixpkgs' VS Code) `pkgs.antigravity` package — explicitly **not** the FHS-wrapped `pkgs.antigravity-fhs` — to the home-manager config. Also removes the now-unused public `gemini-cli` package.

## Changes
- New option `cosmo.antigravity.enable` in `home/dev.nix`, type bool, **default false**. Installs the native Antigravity IDE when enabled.
- `pkgs.antigravity` is added to `home.packages` only when the option is true (`lib.optional`).
- Enabled for classic-laddie's home profile (`cosmo.antigravity.enable = true`).
- Removed the `cosmo.gemini.enable` option and the gated `pkgs.gemini-cli` install from `home/dev.nix` (no longer used).

Default-false keeps Antigravity off the headless/WSL/Crostini/standalone-home-manager hosts where unfree isn't allowed and there's no GPU. Antigravity is unfree; `nixpkgs.config.allowUnfree = true` is already set for classic-laddie (`hosts/classic-laddie/hardware.nix`), so it builds there without any global allowUnfree change.

## Validation
- `nix eval .#nixosConfigurations.classic-laddie.pkgs.antigravity.name` → `antigravity-1.23.2`
- `nix eval .#nixosConfigurations.classic-laddie.config.system.build.toplevel.drvPath` evaluates with no errors (after the gemini-cli removal too)
- Confirmed nothing else in the repo references `cosmo.gemini.enable` or `pkgs.gemini-cli`
- nixfmt / pre-commit hooks pass

Run: 20260614-2114-fa33cc67