### PR TITLE
fix(system): set autoUpgrade operation to boot

### DIFF
--- a/modules/common/system.nix
+++ b/modules/common/system.nix
@@ -77,7 +77,7 @@
       # Build the new generation and set it as the boot default WITHOUT
       # activating it live. Switching on a running session reloads the NVIDIA
       # driver/nvidia_drm, which drops the DRM connector and crashes Hyprland.
-      operation = "boot";
+      operation = lib.mkDefault "boot";
       flags = [
         "-L" # print build logs
         "--no-write-lock-file"

--- a/modules/common/system.nix
+++ b/modules/common/system.nix
@@ -74,6 +74,10 @@
     system.autoUpgrade = {
       enable = true;
       flake = "github:patflynn/cosmo";
+      # Build the new generation and set it as the boot default WITHOUT
+      # activating it live. Switching on a running session reloads the NVIDIA
+      # driver/nvidia_drm, which drops the DRM connector and crashes Hyprland.
+      operation = "boot";
       flags = [
         "-L" # print build logs
         "--no-write-lock-file"


### PR DESCRIPTION
On classic-laddie (NVIDIA RTX 4090, Wayland/Hyprland), the nightly `system.autoUpgrade` runs `nixos-rebuild switch`. When a build includes an NVIDIA driver bump, switching activates it live and reloads the `nvidia_drm` kernel module, which drops the DRM connector out from under the running compositor. Hyprland then SEGVs during the monitor disconnect→headless-output transition (crash chain: `CSession::dispatchUdevEvents` → `CDRMBackend::recheckOutputs` → `SDRMConnector::disconnect` → `CMonitor::onDisconnect` → `enterUnsafeState` → `onConnect` → `sendFrameEventsToWorkspace` → `Desktop::View::getViewsForWorkspace`, null workspace deref). Two crash reports were captured (2026-06-14 02:59 and 2026-06-15 23:04), both at rebuild-activation time.

## Change

Set `system.autoUpgrade.operation = "boot"` in `modules/common/system.nix`. This builds the new generation and sets it as the boot default **without** activating it on the running system, so the nightly upgrade no longer reloads the GPU driver on a live session. The new generation takes effect on the next reboot instead.

This module is imported by all hosts, which is the intended scope.

## Validation

- `nix eval .#nixosConfigurations.classic-laddie.config.system.autoUpgrade.operation` → `"boot"`
- `nix eval .#nixosConfigurations.classic-laddie.config.system.build.toplevel.drvPath` evaluates with no errors

Run: 20260616-0902-112c196e