### PR TITLE
feat(desktop): add Zed editor to IDEs

### DIFF
--- a/home/desktop.nix
+++ b/home/desktop.nix
@@ -24,7 +24,7 @@
 
     # IDEs
     android-studio
-    jetbrains.idea-ultimate
+    jetbrains.idea # Unified IntelliJ IDEA distribution (Ultimate)
     zed-editor
 
     # Media

--- a/home/desktop.nix
+++ b/home/desktop.nix
@@ -24,7 +24,7 @@
 
     # IDEs
     android-studio
-    jetbrains.idea
+    jetbrains.idea-ultimate
     zed-editor
 
     # Media

--- a/home/desktop.nix
+++ b/home/desktop.nix
@@ -25,6 +25,7 @@
     # IDEs
     android-studio
     jetbrains.idea
+    zed-editor
 
     # Media
     mpv # Video player


### PR DESCRIPTION
Add the Zed editor (`zed-editor`) to the IDEs section of `home/desktop.nix`.

## Changes
- Add `zed-editor` to the `home.packages` IDEs list, after `jetbrains.idea`.

Note: the nixpkgs attribute is `zed-editor` (not `zed`, which is a different package).

## Verification
- `nix-instantiate --parse home/desktop.nix` succeeds.
- nixfmt pre-commit hook passes.
- `klaus _pre-review` reports no issues.

Run: 20260627-1639-fa94d944