### PR TITLE
home/zed.nix: preserve existing Zed settings (Claude Code, keymap, Ayu Dark)

### DIFF
--- a/home/zed.nix
+++ b/home/zed.nix
@@ -4,16 +4,35 @@
   programs.zed-editor = {
     enable = true;
 
-    # Auto-installed on first launch. catppuccin resolves the theme below;
-    # nix/toml add language support.
+    # Auto-installed on first launch. nix/toml add language support.
+    # The Ayu and One theme families are bundled with Zed, so no theme
+    # extension is needed for the theme below.
     extensions = [
-      "catppuccin"
       "nix"
       "toml"
     ];
 
     userSettings = {
-      theme = "Catppuccin Mocha"; # matches kitty/gtk/fuzzel Catppuccin Mocha
+      # Claude Code is registered as an ACP agent server ("claude-acp",
+      # sourced from the registry). It runs on the user's Claude
+      # subscription via the `claude` CLI (home/dev.nix), not a
+      # pay-per-token API key.
+      agent_servers = {
+        claude-acp = {
+          type = "registry";
+        };
+      };
+
+      # Mode-aware theme: Ayu Dark when the system is in dark mode, One
+      # Light otherwise. Both are bundled with Zed (no extension needed).
+      theme = {
+        mode = "dark";
+        light = "One Light";
+        dark = "Ayu Dark";
+      };
+
+      # JetBrains-style keybindings (muscle memory from IntelliJ/PyCharm).
+      base_keymap = "JetBrains";
 
       # Vim mode with learning-friendly aids (Emacs user picking up vim).
       # Relative line numbers make vim motion counts easy to read off.
@@ -23,7 +42,8 @@
       # Editor defaults. JetBrainsMono Nerd Font is installed system-wide via
       # home/waybar.nix (nerd-fonts.jetbrains-mono).
       buffer_font_family = "JetBrainsMono Nerd Font";
-      buffer_font_size = 14;
+      buffer_font_size = 15;
+      ui_font_size = 16;
       format_on_save = "on";
       tab_size = 2;
       minimap = {
@@ -60,15 +80,6 @@
           };
         };
       };
-
-      # AI: this runs on the user's Claude Pro/Max *subscription*, not a
-      # pay-per-token console API key. Zed 1.8 ships first-class built-in
-      # Claude Code support (agent id "claude-acp", sourced from the ACP
-      # registry): it auto-detects the `claude` binary on PATH — provided
-      # here by home/dev.nix (pkgs.claude-code) and already logged in via
-      # OAuth — so no `language_models.anthropic` API-key config or
-      # `default_model` is needed. Open the agent panel, pick "Claude Code"
-      # from the New Thread menu, and it uses the CLI's subscription login.
     };
   };
 }

--- a/home/zed.nix
+++ b/home/zed.nix
@@ -23,8 +23,10 @@
         };
       };
 
-      # Mode-aware theme: Ayu Dark when the system is in dark mode, One
-      # Light otherwise. Both are bundled with Zed (no extension needed).
+      # Always use the dark theme (Ayu Dark), regardless of the system's
+      # light/dark setting. The `light`/`dark` keys name the theme for each
+      # mode; `mode = "dark"` pins the active one. Both themes are bundled
+      # with Zed (no extension needed).
       theme = {
         mode = "dark";
         light = "One Light";


### PR DESCRIPTION
## Summary

`home/zed.nix` (just merged) let home-manager own Zed's `settings.json` declaratively, but its values did not match the user's hand-tuned working config and would have clobbered it. The user has decided home-manager *should* own the file — this change makes the declarative config reproduce the working setup instead of replacing it.

Changes in `programs.zed-editor.userSettings`:

- **Claude Code (critical):** added an explicit `agent_servers.claude-acp = { type = "registry"; }`. This is how Claude Code is actually registered in Zed and matches the user's working config; it runs on the user's Claude subscription via the `claude` CLI (`home/dev.nix`), no API key. The previous file omitted this and relied on a comment assuming auto-detection, which would not have registered the agent.
- **Theme:** replaced `theme = "Catppuccin Mocha";` with the user's mode-aware object `{ mode = "dark"; light = "One Light"; dark = "Ayu Dark"; }`.
- **Keymap:** added `base_keymap = "JetBrains";`.
- **Fonts:** added `ui_font_size = 16;` and changed `buffer_font_size` from 14 to 15. `buffer_font_family` (`JetBrainsMono Nerd Font`) unchanged.
- **Extensions:** removed `"catppuccin"` (no longer the theme); kept `"nix"` and `"toml"`.

Verified the **Ayu** and **One** theme families are bundled directly in the Zed 1.8.2 binary (found `Ayu Dark`, `Ayu Light`, `One Light`, `One Dark` in the compiled theme assets), so no theme extension is required — nothing added for the theme.

Everything else (vim_mode, relative_line_numbers, format_on_save, tab_size, minimap.show = never, telemetry off, git inline blame, the nixd LSP config, and the Nix languages block) is retained. `home/desktop.nix` is untouched.

## Verification

- Evaluated `nixosConfigurations.johnny-walker` (imports `home/desktop.nix` → `zed.nix`); the generated `userSettings` JSON matches the source-of-truth config exactly.
- `nix fmt` (nixfmt-tree) — clean.
- `klaus _pre-review` — no issues.

## How home-manager writes `settings.json` (guidance for the human)

Inspected the pinned home-manager `programs.zed-editor` module (`modules/programs/zed-editor.nix`, rev `abfad3d`).

**(a) Mutable file, not a symlink.** With the default `mutableUserSettings = true` (this config does not override it), `settings.json` is **not** symlinked into the nix store. Instead a home-manager activation script (`zedSettingsActivation`) writes a normal, writable file. Zed can continue to self-edit it afterward. It does this by reading the existing file as `$dynamic`, the nix-generated settings as `$static`, and merging with jq `$dynamic * $static` (deep recursive merge, nix values winning on key conflicts), then writing the result back in place.

**(b) First-rebuild collision.** Because settings are merged by an activation script rather than symlinked via `linkGeneration`, there is **no hard clobber collision** and **no `.backup` file** is produced for `settings.json`. The user does **not** need to remove or rename their existing `~/.config/zed/settings.json` before the first rebuild — the activation merges it. On conflicting keys the nix values win, which is intended here since this config reproduces the user's current values. Any extra keys not covered by nix are preserved. The existing backup at `~/.config/zed/settings.json.pre-hm-backup` is belt-and-suspenders; if the merge ever produces something unexpected, the user can restore from it.

Run: 20260702-0609-32697f21
