### PR TITLE
Set Emacs as the default editor (EDITOR/VISUAL)

### DIFF
--- a/home/common.nix
+++ b/home/common.nix
@@ -163,5 +163,12 @@
     enable = true;
   };
 
+  # Emacs is the default editor everywhere. `emacsclient -t` attaches to the
+  # daemon above for instant startup; `-a ''` spins one up if it isn't running.
+  home.sessionVariables = {
+    EDITOR = "emacsclient -t -a ''";
+    VISUAL = "emacsclient -t -a ''";
+  };
+
   home.stateVersion = "25.11";
 }


### PR DESCRIPTION
## What

Sets `EDITOR` and `VISUAL` (in `home/common.nix`, next to the emacs daemon) to
`emacsclient -t -a ''` so Emacs is the default editor everywhere — yazi, `git
commit`, `crontab -e`, `sudoedit`, etc.

## Why

`EDITOR` was `nano` (a leaking default — not set anywhere in this repo). This
makes the editor choice explicit and consistent with the existing setup
(`services.emacs` daemon, `ed = "emacsclient -t"` alias).

- `emacsclient -t` attaches to the running emacs daemon → instant startup.
- `-a ''` starts a daemon if one isn't running, so it's robust even without the service.
- Both `EDITOR` and `VISUAL` are set so programs pick Emacs regardless of which they consult.

## Verify after switch

```
echo $EDITOR   # → emacsclient -t -a ''
```
Then open a text file in yazi (`o`) — it should open in terminal Emacs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)