### PR TITLE
feat(git-hosting): declarative bare-git hosting on classic-laddie

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,4 @@ See [AGENTS.md](./AGENTS.md) for common administrative commands.
 * [Secrets Management](./docs/secrets-management.md): How to add, edit, and rekey encrypted secrets (Agenix).
 * [Generic VM Setup](./docs/vm-setup.md): How to build and deploy NixOS VMs (e.g., `johnny-walker`).
 * [Crostini Setup](./docs/crostini-setup.md): Setup guide for the standalone Home Manager configuration on Crostini.
+* [Git Hosting](./docs/git-hosting.md): Self-hosted bare git repositories on `classic-laddie` (adding repos, cloning over the tailnet, hooks).

--- a/docs/git-hosting.md
+++ b/docs/git-hosting.md
@@ -1,0 +1,71 @@
+# Git Hosting (classic-laddie)
+
+`classic-laddie` hosts bare git repositories as the canonical origin for
+personal repos (source-hosting migration Phase 0). The reusable module lives
+in `modules/git-hosting/` and is enabled in `hosts/classic-laddie/default.nix`.
+
+Repos live on the ZFS pool at `/mnt/git` (dataset `tank/git`), owned by a
+dedicated `git` user whose shell is `git-shell` — no interactive login, SSH
+keys only. Access control is deliberately thin: Tailscale ACLs plus the SSH
+keys in `secrets/keys.nix` (`users`) are the whole identity story.
+
+## One-time host prep
+
+The ZFS dataset is not created by the module. Before the first deploy that
+enables the module:
+
+```bash
+sudo zfs create -o mountpoint=legacy tank/git
+```
+
+## Adding a repo
+
+Add the name (no `.git` suffix) to the repo list in
+`hosts/classic-laddie/default.nix`:
+
+```nix
+services.git-hosting.repos = [
+  "the-valley"
+  "new-repo"
+];
+```
+
+On the next rebuild, `/mnt/git/new-repo.git` is created as an empty bare
+repository (initial branch `main`). Existing repositories are never touched;
+removing a name from the list leaves its data in place on disk.
+
+## Cloning and pushing
+
+Over the tailnet, SSH to the `git` user on `classic-laddie`:
+
+```bash
+git clone git@classic-laddie:the-valley.git
+```
+
+To point an existing checkout at the new origin:
+
+```bash
+git remote add origin git@classic-laddie:the-valley.git   # or `set-url`
+git push -u origin main
+```
+
+Paths are relative to the git user's home (`/mnt/git`), so the bare
+`name.git` form works. Any key in `secrets/keys.nix` `users` can push; to
+grant access to a new machine, add its key there (and rekey — see
+[secrets-management](./secrets-management.md)).
+
+## Hooks
+
+Each repo's `post-receive` is a managed dispatcher that runs every
+executable in the repo's `post-receive.d/` directory, in order:
+
+```
+/mnt/git/<name>.git/hooks/post-receive      # managed symlink — do not edit
+/mnt/git/<name>.git/hooks/post-receive.d/   # drop executable hooks here
+```
+
+Each hook receives the standard post-receive input (`<old> <new> <ref>`
+lines) on stdin. This is the wiring point for the planned offsite
+replication hook (Hetzner mirror, follow-up work). A hand-written
+`post-receive` file is left alone by the module; only the managed symlink is
+updated across rebuilds.

--- a/hosts/classic-laddie/default.nix
+++ b/hosts/classic-laddie/default.nix
@@ -16,6 +16,7 @@
     ../../modules/common/gaming.nix
     ../../modules/common/ddcci.nix
     ../../modules/media-server/default.nix
+    ../../modules/git-hosting/default.nix
     inputs.reel-life.nixosModules.default
     inputs.github-relay.nixosModules.default
   ];
@@ -113,6 +114,19 @@
   #   cd secrets && agenix -e radarr-api-key.age   # paste the API key from Radarr UI → Settings → General
   #   cd secrets && agenix -e prowlarr-api-key.age  # paste the API key from Prowlarr UI → Settings → General
   modules.media-server.recyclarr.enable = true;
+
+  # ---------------------------------------------------------------------------
+  # Git hosting (canonical origin for personal repos — source hosting Phase 0)
+  # ---------------------------------------------------------------------------
+  # Clone/push over the tailnet: git clone git@classic-laddie:the-valley.git
+  # One-time host prep: sudo zfs create -o mountpoint=legacy tank/git
+  # See docs/git-hosting.md.
+  services.git-hosting = {
+    enable = true;
+    dataDir = "/mnt/git";
+    repos = [ "the-valley" ];
+    authorizedKeys = (import ../../secrets/keys.nix).users;
+  };
 
   # ---------------------------------------------------------------------------
   # Reel-life media chatops agent (direct systemd service)
@@ -401,6 +415,11 @@
 
   fileSystems."/mnt/media" = {
     device = "tank/media";
+    fsType = "zfs";
+  };
+
+  fileSystems."/mnt/git" = {
+    device = "tank/git";
     fsType = "zfs";
   };
 

--- a/modules/git-hosting/default.nix
+++ b/modules/git-hosting/default.nix
@@ -1,0 +1,155 @@
+# Declarative bare-git hosting over SSH.
+# Provides a dedicated git user (git-shell, key-only) and ensures a bare
+# repository exists for every name in `repos`. Repos are only ever created,
+# never deleted or overwritten — removing a name from the list leaves the
+# data on disk untouched.
+#
+# Identity is deliberately thin: the host lives on the tailnet, so Tailscale
+# ACLs plus the SSH keys in `authorizedKeys` are the whole access story.
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.git-hosting;
+
+  # Managed post-receive dispatcher. Each repo's post-receive is a symlink to
+  # this script, which chains every executable dropped into the repo's
+  # hooks/post-receive.d/ directory (e.g. a future replication hook).
+  postReceiveDispatch = pkgs.writeShellScript "git-hosting-post-receive" ''
+    # Managed by services.git-hosting — do not edit.
+    # Drop executable hooks into post-receive.d/ next to this symlink.
+    set -eu
+    hook_dir="$(dirname "$0")/post-receive.d"
+    [ -d "$hook_dir" ] || exit 0
+    updates="$(cat)"
+    for hook in "$hook_dir"/*; do
+      [ -x "$hook" ] || continue
+      printf '%s\n' "$updates" | "$hook" "$@"
+    done
+  '';
+in
+{
+  options.services.git-hosting = {
+    enable = lib.mkEnableOption "declarative bare-git repository hosting over SSH";
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "git";
+      description = "System user that owns the repositories and accepts SSH pushes.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "git";
+      description = "Primary group of the git hosting user.";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/srv/git";
+      example = "/mnt/git";
+      description = ''
+        Directory holding the bare repositories, one `<name>.git` per entry
+        in {option}`services.git-hosting.repos`. Also the git user's home,
+        so clone URLs are relative to it (`git@host:name.git`).
+      '';
+    };
+
+    repos = lib.mkOption {
+      type = lib.types.listOf (lib.types.strMatching "[a-zA-Z0-9][a-zA-Z0-9._-]*");
+      default = [ ];
+      example = [ "the-valley" ];
+      description = ''
+        Repository names to host (without the `.git` suffix). Each becomes a
+        bare repository at `<dataDir>/<name>.git`, created on activation if
+        missing. Existing repositories are never touched or deleted.
+      '';
+    };
+
+    authorizedKeys = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "SSH public keys allowed to push/fetch as the git user.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.authorizedKeys != [ ];
+        message = "services.git-hosting.authorizedKeys must not be empty — the git user would be unreachable.";
+      }
+    ];
+
+    users.groups.${cfg.group} = { };
+
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      group = cfg.group;
+      home = cfg.dataDir;
+      # git-shell only allows git-upload-pack/git-receive-pack/git-upload-archive;
+      # interactive logins are rejected (no ~/git-shell-commands).
+      shell = "${pkgs.git}/bin/git-shell";
+      openssh.authorizedKeys.keys = cfg.authorizedKeys;
+    };
+
+    services.openssh.enable = lib.mkDefault true;
+
+    # Belt-and-braces hardening for the git user; goes at the end of
+    # sshd_config so the Match block doesn't leak into other directives.
+    services.openssh.extraConfig = ''
+      Match User ${cfg.user}
+        AllowTcpForwarding no
+        AllowAgentForwarding no
+        X11Forwarding no
+        PermitTunnel no
+    '';
+
+    # git-shell spawns git-receive-pack/git-upload-pack from PATH
+    environment.systemPackages = [ pkgs.git ];
+
+    systemd.tmpfiles.rules = [
+      "d ${cfg.dataDir} 0750 ${cfg.user} ${cfg.group} - -"
+    ];
+
+    # Create missing bare repos and (re)wire the managed post-receive
+    # dispatcher on every activation where the repo list changed.
+    systemd.services.git-hosting-init = {
+      description = "Initialize declarative bare git repositories";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "systemd-tmpfiles-setup.service" ];
+      unitConfig.RequiresMountsFor = cfg.dataDir;
+      serviceConfig = {
+        Type = "oneshot";
+        User = cfg.user;
+        Group = cfg.group;
+      };
+      path = [ pkgs.git ];
+      script = ''
+        for name in ${lib.escapeShellArgs cfg.repos}; do
+          repo="${cfg.dataDir}/$name.git"
+          if [ ! -d "$repo" ]; then
+            git init --bare --initial-branch=main "$repo"
+          fi
+
+          # Hook scaffolding: post-receive dispatches to post-receive.d/.
+          # Only manage the hook if it is absent or already ours (a store
+          # symlink) — a hand-written hook is left alone.
+          mkdir -p "$repo/hooks/post-receive.d"
+          hook="$repo/hooks/post-receive"
+          if [ -L "$hook" ]; then
+            case "$(readlink "$hook")" in
+              /nix/store/*) ln -sfn ${postReceiveDispatch} "$hook" ;;
+            esac
+          elif [ ! -e "$hook" ]; then
+            ln -s ${postReceiveDispatch} "$hook"
+          fi
+        done
+      '';
+    };
+  };
+}

--- a/modules/git-hosting/default.nix
+++ b/modules/git-hosting/default.nix
@@ -26,6 +26,7 @@ let
     hook_dir="$(dirname "$0")/post-receive.d"
     [ -d "$hook_dir" ] || exit 0
     updates="$(cat)"
+    [ -n "$updates" ] || exit 0
     for hook in "$hook_dir"/*; do
       [ -x "$hook" ] || continue
       printf '%s\n' "$updates" | "$hook" "$@"
@@ -99,14 +100,16 @@ in
 
     services.openssh.enable = lib.mkDefault true;
 
-    # Belt-and-braces hardening for the git user; goes at the end of
-    # sshd_config so the Match block doesn't leak into other directives.
+    # Belt-and-braces hardening for the git user. The trailing `Match All`
+    # closes the block so it can't scope directives appended to sshd_config
+    # after this snippet.
     services.openssh.extraConfig = ''
       Match User ${cfg.user}
         AllowTcpForwarding no
         AllowAgentForwarding no
         X11Forwarding no
         PermitTunnel no
+      Match All
     '';
 
     # git-shell spawns git-receive-pack/git-upload-pack from PATH
@@ -130,9 +133,12 @@ in
       };
       path = [ pkgs.git ];
       script = ''
-        for name in ${lib.escapeShellArgs cfg.repos}; do
+        repos=( ${lib.escapeShellArgs cfg.repos} )
+        for name in "''${repos[@]}"; do
           repo="${cfg.dataDir}/$name.git"
-          if [ ! -d "$repo" ]; then
+          # Check HEAD rather than the directory itself so a pre-existing
+          # empty directory still gets initialized.
+          if [ ! -e "$repo/HEAD" ]; then
             git init --bare --initial-branch=main "$repo"
           fi
 


### PR DESCRIPTION
Phase 0 of the source-hosting migration off GitHub: classic-laddie becomes the canonical origin for personal repos, starting with `the-valley`. Hosting only — no web UI, no CI, no event bus.

## Option surface (`modules/git-hosting/`)

| Option | Type | Default | classic-laddie |
|---|---|---|---|
| `services.git-hosting.enable` | bool | `false` | `true` |
| `services.git-hosting.user` | str | `"git"` | (default) |
| `services.git-hosting.group` | str | `"git"` | (default) |
| `services.git-hosting.dataDir` | path | `"/srv/git"` | `"/mnt/git"` (new `tank/git` ZFS dataset) |
| `services.git-hosting.repos` | list of str (name-safe regex) | `[ ]` | `[ "the-valley" ]` |
| `services.git-hosting.authorizedKeys` | list of str | `[ ]` (asserted non-empty) | `keys.users` from `secrets/keys.nix` |

## Behavior

- Dedicated `git` system user with `${pkgs.git}/bin/git-shell` — no interactive login, key-only SSH, plus an sshd `Match` block disabling forwarding/tunnels for that user. Identity stays thin by design: Tailscale ACLs + the existing user keys in `secrets/keys.nix` are the whole access story.
- A oneshot `git-hosting-init` service creates `<dataDir>/<name>.git` (bare, initial branch `main`) for each listed repo on activation. **Create-only**: existing repos are never touched; removing a name leaves data on disk.
- Hook scaffolding for future replication: each repo's `post-receive` is a managed store symlink to a dispatcher that pipes the push input to every executable in `hooks/post-receive.d/`. The offsite (Hetzner) mirror hook is follow-up work — no remote endpoints invented here. Hand-written `post-receive` files are left alone (only store symlinks are ever replaced).
- Clone/push over the tailnet: `git clone git@classic-laddie:the-valley.git`. Docs in `docs/git-hosting.md` (linked from README).

## Deploy notes (manual, pre-deploy)

- Create the dataset once before rebuilding: `sudo zfs create -o mountpoint=legacy tank/git` (module follows the existing `tank/personal` / `tank/media` legacy-mount convention; the `fileSystems."/mnt/git"` entry is in the host config).
- No secrets needed: auth reuses the existing public keys in `secrets/keys.nix` (unchanged, so no rekey).

## Testing

- `nix flake check` — all checks passed (pre-commit: nixfmt, detect-private-keys, zizmor).
- `nix build .#nixosConfigurations.classic-laddie.config.system.build.toplevel --dry-run` — evaluates cleanly (matches CI).
- Built the generated `check-sshd-config` derivation to validate the sshd `Match` block.
- `klaus _pre-review` — passed (one MEDIUM finding in `home/common.nix`, untouched by this PR).

Not deployed — config PR only.

Run: 20260704-1610-459448fa