### PR TITLE
classic-laddie: crash-capture / hang-recovery hardening (Track A)

### DIFF
--- a/hosts/classic-laddie/default.nix
+++ b/hosts/classic-laddie/default.nix
@@ -15,6 +15,7 @@
     ../../modules/common/desktop.nix
     ../../modules/common/gaming.nix
     ../../modules/common/ddcci.nix
+    ../../modules/common/crash-capture.nix
     ../../modules/media-server/default.nix
     inputs.reel-life.nixosModules.default
     inputs.github-relay.nixosModules.default
@@ -95,6 +96,17 @@
   modules.ddcci.enable = true;
 
   modules.gaming.enable = true;
+
+  # ---------------------------------------------------------------------------
+  # Crash capture / hang recovery (Track A of the silent-freeze diagnosis)
+  # ---------------------------------------------------------------------------
+  # Enabled ONLY on classic-laddie: this box has a chronic history of silent hard
+  # lockups (27 unclean reboots since 2026-03, across 12 kernel versions). The
+  # module turns detectable lockups into panic+reboot (so the machine self-
+  # recovers instead of sitting dead), logs high-frequency thermal/load telemetry
+  # to the persistent journal, and archives any pstore panic record on next boot.
+  # Left OFF everywhere else (build workers / microVMs must never self-panic).
+  modules.crashCapture.enable = true;
 
   # Auto-login to desktop session
   services.displayManager.autoLogin = {

--- a/modules/common/crash-capture.nix
+++ b/modules/common/crash-capture.nix
@@ -1,0 +1,181 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.modules.crashCapture;
+
+  # High-frequency telemetry sample. Runs every ~30s (see the timer below) and
+  # writes ONE compact line to the journal under SyslogIdentifier=crash-telemetry.
+  # journald on this host stores persistently (services.journald.storage =
+  # "persistent" → /var/log/journal), so the samples survive the reboot. After
+  # the NEXT silent freeze the journal tail therefore shows the thermal + load
+  # trajectory in the final seconds before death — directly answering "was it
+  # heat, a runaway load, or swap thrash?", which is exactly the data we lacked
+  # when classic-laddie locked up mid-stream on 2026-07-08.
+  telemetryScript = pkgs.writeShellScript "crash-telemetry" ''
+    # Restricted PATH of cheap sampling tools (all already pulled in by
+    # modules/common/health.nix, so no new closure cost). /run/current-system/sw/bin
+    # is appended so the system-wide `nvidia-smi` — shipped by the NVIDIA driver's
+    # `.bin` output, not part of nixpkgs' makeBinPath set — is found at runtime.
+    PATH="${
+      lib.makeBinPath (
+        with pkgs;
+        [
+          coreutils
+          procps
+          lm_sensors
+          gawk
+        ]
+      )
+    }:/run/current-system/sw/bin:$PATH"
+
+    # --- CPU package/CCD temperatures ---
+    # k10temp on the Zen 3 5950X exposes Tctl (control temp) and Tccd1/Tccd2 (per-
+    # die). Emitted compact as "Tctl=+52.4°C Tccd1=+48.5°C ..." so a lockup shows
+    # the thermal ramp, not a single snapshot.
+    cpu=$(sensors 2>/dev/null \
+      | awk '/^(Tctl|Tdie|Tccd[0-9]):/ {name=$1; sub(/:$/, "", name); printf "%s=%s ", name, $2}')
+    [ -n "$cpu" ] || cpu="unavailable"
+
+    # --- GPU temperature / utilisation / VRAM used ---
+    # Guarded: nvidia-smi can be momentarily absent (e.g. during a driver reload),
+    # and the sampler must keep logging the CPU/load side rather than fail the unit.
+    if command -v nvidia-smi >/dev/null 2>&1; then
+      gpu=$(nvidia-smi --query-gpu=temperature.gpu,utilization.gpu,memory.used \
+        --format=csv,noheader 2>/dev/null | head -1)
+      [ -n "$gpu" ] || gpu="unavailable"
+    else
+      gpu="unavailable"
+    fi
+
+    # --- 1-minute load average ---
+    load=$(cut -d' ' -f1 /proc/loadavg)
+
+    # --- Memory and swap usage (used/total, human units) ---
+    mem=$(free -h | awk '/^Mem:/  {print $3 "/" $2}')
+    swap=$(free -h | awk '/^Swap:/ {print $3 "/" $2}')
+
+    # --- Single top CPU-consuming process (cheap ps snapshot, no sampling window) ---
+    top=$(ps -eo comm=,pcpu= --sort=-pcpu 2>/dev/null | head -1 | awk '{print $1 "(" $2 "%)"}')
+
+    echo "cpu[$cpu] gpu[$gpu] load=$load mem=$mem swap=$swap top=$top"
+  '';
+in
+{
+  options.modules.crashCapture = {
+    enable = lib.mkEnableOption "Crash-capture / hang-recovery hardening (panic-on-lockup, high-frequency telemetry, pstore archival)";
+  };
+
+  config = lib.mkIf cfg.enable {
+    # ---------------------------------------------------------------------------
+    # (1) Auto-recover + turn detectable lockups into reboots
+    # ---------------------------------------------------------------------------
+    # panic=20: after ANY kernel panic, reboot 20s later instead of sitting dead
+    # forever waiting on a physical hard reset (classic-laddie sat wedged for ~3
+    # days after the 2026-07-08 freeze). This list merges with the existing
+    # `boot.kernelParams = [ "usbcore.autosuspend=-1" ]` in
+    # hosts/classic-laddie/hardware.nix — NixOS concatenates kernelParams, no conflict.
+    boot.kernelParams = [ "panic=20" ];
+
+    # Convert the failure modes we CAN detect into panics, so panic=20 can recover
+    # them and any pstore backend can capture them:
+    boot.kernel.sysctl = {
+      # An oops is already-corrupted kernel state; continuing risks silent damage.
+      # Panic instead so we reboot cleanly and leave a trace.
+      "kernel.panic_on_oops" = 1;
+
+      # softlockup: a CPU stuck in kernel mode >20s without scheduling. The soft
+      # watchdog already detects it; this makes it panic-and-reboot instead of
+      # only logging a warning into a journal nothing will ever read post-freeze.
+      "kernel.softlockup_panic" = 1;
+
+      # hardlockup: a CPU wedged with interrupts disabled, caught by the NMI
+      # watchdog (already enabled — nmi_watchdog=1). This is the single most
+      # valuable setting for our symptom: a true silent hard lockup is precisely
+      # what the NMI detector is for. Without this it only WARNs; with it the box
+      # panics and — via panic=20 — reboots itself instead of hanging until a
+      # human power-cycles it.
+      "kernel.hardlockup_panic" = 1;
+
+      # DELIBERATELY OMITTED: kernel.hung_task_panic.
+      # hung_task fires on tasks stuck in uninterruptible D-state on I/O — which is
+      # EXPECTED here, not a fault. modules/common/system.nix documents a benign
+      # ~122s hung_task_timeout during NVMe swap-in (the 2026-04-29
+      # shmem_swapin_folio D-state stall, since mitigated with zram). Panicking on
+      # hung_task would reboot the box mid-build / mid-swap on a non-crash. The
+      # hard/soft-lockup detectors above target true CPU lockups and do NOT
+      # false-fire on I/O waits, so they are the safe subset to panic on.
+    };
+
+    # ---------------------------------------------------------------------------
+    # (2) High-frequency telemetry to the persistent journal
+    # ---------------------------------------------------------------------------
+    # The highest-value, zero-risk diagnostic: the periodic health check in
+    # health.nix only samples HOURLY, so on 2026-07-08 we had no idea what the
+    # box was doing in the minutes before it froze. This samples every ~30s.
+    systemd.services.crash-telemetry = {
+      description = "Sample CPU/GPU thermals + load for crash post-mortem";
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = telemetryScript;
+        # Distinct identifier so the whole trajectory is filterable after a
+        # freeze with: journalctl -t crash-telemetry
+        SyslogIdentifier = "crash-telemetry";
+        # Keep the sampler out of the way of real work — it must observe load,
+        # never add to it.
+        Nice = 19;
+        IOSchedulingClass = "idle";
+      };
+    };
+
+    systemd.timers.crash-telemetry = {
+      description = "Trigger crash-telemetry sample every 30s";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnBootSec = "1min";
+        OnUnitActiveSec = "30s";
+        # systemd's default AccuracySec is 1 minute, which would coalesce our 30s
+        # cadence back to roughly one sample per minute. Tighten it so we actually
+        # get sub-minute resolution right before a freeze.
+        AccuracySec = "1s";
+      };
+    };
+
+    # ---------------------------------------------------------------------------
+    # (3) Best-effort persistent panic capture (pstore)
+    # ---------------------------------------------------------------------------
+    # NixOS already enables systemd-pstore.service (wantedBy = sysinit.target), so
+    # on the next boot anything a pstore backend captured in /sys/fs/pstore is
+    # archived to /var/lib/systemd/pstore automatically. We make the archival
+    # policy explicit (and self-documenting) rather than relying on systemd's
+    # compiled-in defaults:
+    #   Storage=external → copy panic records into /var/lib/systemd/pstore
+    #   Unlink=yes       → clear /sys/fs/pstore afterwards so the (tiny, e.g.
+    #                      EFI-variable) backend has room for the next panic.
+    #
+    # Which backend actually captures the panic is board-dependent. On this AM4
+    # box efi_pstore (panic dmesg → EFI variables) is the likely one; ACPI ERST
+    # may or may not be exposed by consumer AM4 firmware. Crucially, (1) above is
+    # what makes this useful at all: a truly silent hard lockup executes no panic
+    # path and writes nothing — but with hardlockup_panic=1 the NMI watchdog now
+    # turns that lockup INTO a panic, which a backend can then record before the
+    # panic=20 warm reboot preserves it.
+    #
+    # ramoops (pstore/ram) is DELIBERATELY NOT configured: on x86 it needs a
+    # hard-coded reserved physical address (mem_address/mem_size) that is
+    # board-specific and risky to guess; shipping a pinned-address guess could
+    # corrupt memory the firmware/kernel actually uses. The telemetry-to-journal
+    # path in (2) is already a solid reboot-surviving capture, and netconsole to
+    # an always-on LAN host is the recommended follow-up for guaranteed hard-hang
+    # capture (see PR description, Track B).
+    environment.etc."systemd/pstore.conf".text = ''
+      [PStore]
+      Storage=external
+      Unlink=yes
+    '';
+  };
+}

--- a/modules/common/crash-capture.nix
+++ b/modules/common/crash-capture.nix
@@ -17,6 +17,11 @@ let
   # heat, a runaway load, or swap thrash?", which is exactly the data we lacked
   # when classic-laddie locked up mid-stream on 2026-07-08.
   telemetryScript = pkgs.writeShellScript "crash-telemetry" ''
+    # Force the C locale so `free`, `sensors`, `ps`, etc. emit their canonical
+    # English output. Under a localized LC_* the field labels and decimal
+    # separators can differ, which would silently break the awk parsing below.
+    export LC_ALL=C
+
     # Restricted PATH of cheap sampling tools (all already pulled in by
     # modules/common/health.nix, so no new closure cost). /run/current-system/sw/bin
     # is appended so the system-wide `nvidia-smi` — shipped by the NVIDIA driver's
@@ -60,7 +65,10 @@ let
     swap=$(free -h | awk '/^Swap:/ {print $3 "/" $2}')
 
     # --- Single top CPU-consuming process (cheap ps snapshot, no sampling window) ---
-    top=$(ps -eo comm=,pcpu= --sort=-pcpu 2>/dev/null | head -1 | awk '{print $1 "(" $2 "%)"}')
+    # pcpu first so $1 is always the CPU percentage; the rest of the line is the
+    # process name, reconstructed after stripping the leading gap. Ordering comm
+    # first would misalign $2 whenever a process name contains spaces.
+    top=$(ps -eo pcpu=,comm= --sort=-pcpu 2>/dev/null | head -1 | awk '{pcpu=$1; $1=""; sub(/^[ \t]+/, ""); print $0 "(" pcpu "%)"}')
 
     echo "cpu[$cpu] gpu[$gpu] load=$load mem=$mem swap=$swap top=$top"
   '';
@@ -79,6 +87,13 @@ in
     # days after the 2026-07-08 freeze). This list merges with the existing
     # `boot.kernelParams = [ "usbcore.autosuspend=-1" ]` in
     # hosts/classic-laddie/hardware.nix — NixOS concatenates kernelParams, no conflict.
+    #
+    # NOTE: intentionally NOT wrapped in lib.mkDefault. kernelParams is a list
+    # option: definitions concatenate at equal override priority, but a plain
+    # (priority-100) definition from a host wins outright over a mkDefault
+    # (priority-1000) one, DROPPING it entirely rather than merging. Since
+    # classic-laddie's hardware.nix already sets kernelParams plainly, mkDefault
+    # here would silently delete "panic=20" on exactly the host this targets.
     boot.kernelParams = [ "panic=20" ];
 
     # Convert the failure modes we CAN detect into panics, so panic=20 can recover
@@ -86,12 +101,12 @@ in
     boot.kernel.sysctl = {
       # An oops is already-corrupted kernel state; continuing risks silent damage.
       # Panic instead so we reboot cleanly and leave a trace.
-      "kernel.panic_on_oops" = 1;
+      "kernel.panic_on_oops" = lib.mkDefault 1;
 
       # softlockup: a CPU stuck in kernel mode >20s without scheduling. The soft
       # watchdog already detects it; this makes it panic-and-reboot instead of
       # only logging a warning into a journal nothing will ever read post-freeze.
-      "kernel.softlockup_panic" = 1;
+      "kernel.softlockup_panic" = lib.mkDefault 1;
 
       # hardlockup: a CPU wedged with interrupts disabled, caught by the NMI
       # watchdog (already enabled — nmi_watchdog=1). This is the single most
@@ -99,7 +114,7 @@ in
       # what the NMI detector is for. Without this it only WARNs; with it the box
       # panics and — via panic=20 — reboots itself instead of hanging until a
       # human power-cycles it.
-      "kernel.hardlockup_panic" = 1;
+      "kernel.hardlockup_panic" = lib.mkDefault 1;
 
       # DELIBERATELY OMITTED: kernel.hung_task_panic.
       # hung_task fires on tasks stuck in uninterruptible D-state on I/O — which is
@@ -172,7 +187,7 @@ in
     # path in (2) is already a solid reboot-surviving capture, and netconsole to
     # an always-on LAN host is the recommended follow-up for guaranteed hard-hang
     # capture (see PR description, Track B).
-    environment.etc."systemd/pstore.conf".text = ''
+    environment.etc."systemd/pstore.conf".text = lib.mkDefault ''
       [PStore]
       Storage=external
       Unlink=yes


### PR DESCRIPTION
## Track A: crash-capture / hang-recovery hardening for `classic-laddie`

This is **Track A** of the silent-freeze diagnosis effort. Its goal is **not** to
fix the root cause of the hangs — it is to make the *next* hang **self-recover**
and **leave a diagnostic trace**, because today the machine freezes completely
silently and records nothing about what killed it.

### Background

- `classic-laddie` is a Ryzen 9 5950X (Zen 3, AM4, DDR4, non-ECC) + RTX 4090
  desktop / media-server running NixOS.
- It has a chronic history of hard hangs: **27 unclean "crash" reboots since
  March 2026**, spread across **12 different kernel versions** (6.12.x, 6.18.x,
  6.19.x-zen). Because the crashes span *every* kernel, this is **not** a kernel
  regression — it points at hardware/firmware or a constant (NVIDIA driver, RAM,
  PSU, C-state / idle power).
- Most recent event: on **Wed 2026-07-08 07:44:48** the journal simply **stops
  mid-stream** — routine activity, then silence. No panic, no OOM, no shutdown
  targets. A classic silent hard lockup. The box then sat dead (no SSH, no
  monitor) for ~3 days until it was physically hard-reset.
- Why we can't name the cause: the machine is configured to freeze *silently* —
  `nmi_watchdog` is on but `hardlockup_panic=0`, `softlockup_panic=0`, no
  panic-on-oops, no crash capture (no ramoops/pstore/netconsole), and the
  periodic health check only samples **hourly**.

### What this PR does

New reusable module `modules/common/crash-capture.nix`
(`options.modules.crashCapture.enable`, **default off**, mirroring
`modules/common/health.nix`), imported and enabled **only on `classic-laddie`**.
It does three things:

**1) Auto-recover + turn detectable lockups into panics**

| Setting | Value | Why |
| --- | --- | --- |
| `boot.kernelParams` | `panic=20` | Reboot 20s after any panic instead of sitting dead forever. Merges with the existing `usbcore.autosuspend=-1`. |
| `kernel.panic_on_oops` | `1` | An oops is already-corrupted state; panic + reboot rather than limp on and lose the trace. |
| `kernel.softlockup_panic` | `1` | CPU stuck in kernel mode >20s → panic+reboot instead of a warning nothing will read post-freeze. |
| `kernel.hardlockup_panic` | `1` | **The key one.** The NMI watchdog (already on) detects a truly wedged CPU — this makes it *panic and reboot* instead of only warning. Directly targets our silent-hard-lockup symptom. |

**`kernel.hung_task_panic` was deliberately EXCLUDED.** `hung_task` fires on
tasks stuck in uninterruptible **D-state on I/O**, which is *expected* here:
`modules/common/system.nix` documents a **benign ~122s `hung_task_timeout`**
during NVMe swap-in (the 2026-04-29 `shmem_swapin_folio` D-state stall, since
mitigated with zram). Panicking on `hung_task` would reboot the box mid-build /
mid-swap on a non-crash. The hard/soft-lockup detectors target *true CPU
lockups* and do **not** false-fire on I/O waits, so they are the safe subset to
panic on.

**2) High-frequency telemetry to the persistent journal** — the highest-value,
zero-risk diagnostic, and exactly what we lacked on Jul 8. A
`crash-telemetry.service` + `.timer` samples every **30s** and logs **one
compact line** under `SyslogIdentifier=crash-telemetry`, capturing all CPU temps
(`sensors`), GPU temp/util/VRAM (`nvidia-smi`, guarded so the unit still works if
it's momentarily unavailable), 1-min loadavg, mem+swap usage, and the top
CPU-consuming process. journald here stores persistently
(`services.journald.storage = "persistent"` → `/var/log/journal`), so after the
*next* freeze the journal tail shows the thermal + load trajectory in the final
seconds before death — directly answering "was it heat / a runaway load?". Real
sample from the built script on this hardware:

```
cpu[Tctl=+89.6°C Tccd1=+90.5°C Tccd2=+64.8°C] gpu[37, 3 %, 1436 MiB] load=7.78 mem=26Gi/31Gi swap=3.2Gi/31Gi top=cc1plus(130%)
```

**3) Best-effort persistent panic capture (pstore)** — makes the pstore archival
policy explicit via `/etc/systemd/pstore.conf` (`Storage=external`, `Unlink=yes`).
NixOS already runs `systemd-pstore.service` (wantedBy `sysinit.target`), so on
the next boot anything a pstore backend captured in `/sys/fs/pstore` is archived
to `/var/lib/systemd/pstore`. On this AM4 board `efi_pstore` is the likely
backend; ACPI ERST may or may not be exposed. Combined with (1), a formerly
silent lockup now becomes an NMI panic that a backend can record before the
`panic=20` warm reboot preserves it. **ramoops was deliberately NOT added** — on
x86 it needs a hard-coded reserved physical address that is board-specific and
risky to guess; shipping a pinned-address guess could corrupt memory in use. The
telemetry-to-journal path in (2) is already a solid reboot-surviving capture, and
netconsole (below) is the recommended path for guaranteed hard-hang capture.

### Validation (done before opening this PR)

- `nix eval .#nixosConfigurations.classic-laddie.config.boot.kernelParams` →
  contains **both** `panic=20` and `usbcore.autosuspend=-1`. ✅
- `nix eval --json …config.boot.kernel.sysctl` → `kernel.panic_on_oops`,
  `kernel.softlockup_panic`, `kernel.hardlockup_panic` all `= 1`, and
  **no** `kernel.hung_task_panic`. (`vm.swappiness=10` preserved.) ✅
- `crash-telemetry.service` + `crash-telemetry.timer` present in the evaluated
  config; both unit files, the telemetry script, and `/etc/systemd/pstore.conf`
  build successfully, and the telemetry script runs end-to-end on real Ryzen +
  NVIDIA hardware (sample above). ✅
- `nixfmt --check` clean on both changed files. ✅
- **Note on the full `toplevel` build:** `nix build
  .#nixosConfigurations.classic-laddie.config.system.build.toplevel` currently
  fails on **two pre-existing, unrelated** Python derivations —
  `python3.14-catppuccin-2.5.0` (home-manager GTK theme; its import self-test
  breaks on the pinned `matplotlib.style` API change, `module 'matplotlib.style'
  has no attribute 'core'`) and `python3.14-frictionless-5.18.1`. A
  `--keep-going` build shows these are the **only** two leaf failures; everything
  else (including `scx_full` and every derivation this PR adds) builds cleanly.
  Both failing `.drv`s are requisites of the base `HEAD` toplevel with none of
  these changes present, so they are not introduced here. Fixing those upstream
  Python pins is out of scope for this focused change.

### How to verify after deploy

```bash
# Telemetry trajectory (this is what we lacked on Jul 8):
journalctl -t crash-telemetry -n 50

# Confirm the panic settings landed:
cat /proc/sys/kernel/softlockup_panic   # -> 1
cat /proc/sys/kernel/hardlockup_panic   # -> 1
cat /proc/sys/kernel/panic_on_oops      # -> 1
cat /proc/sys/kernel/hung_task_panic    # -> 0 (deliberately left off)
cat /sys/module/kernel/parameters/panic 2>/dev/null || sysctl kernel.panic  # -> 20

# After a FUTURE panic, the archived record shows up here:
ls -l /sys/fs/pstore /var/lib/systemd/pstore
```

### Recommended follow-ups (out of scope — Track B)

- **netconsole to another always-on LAN host** — the only way to guarantee
  capturing a *true* hard hang (one that executes no panic path at all). Stream
  kernel messages over UDP to a machine that stays up; nothing local survives a
  dead box better than an off-box log.
- **5950X idle-freeze BIOS mitigations** — the classic Zen 3 idle/C-state hang
  profile: set **Power Supply Idle Control = Typical Current Idle**, **update
  BIOS / AGESA**, and **loosen or disable DDR4 XMP** (run at JEDEC to rule out
  memory-training instability).
- **Overnight memtest86+ run** — rule out the non-ECC DDR4 as the constant across
  all 12 kernels.

Run: 20260711-1034-f9cdc76a
