### PR TITLE
home/hyprland: restore Bibata cursor via XCursor (minimal, no hyprcursor theme gen)

### DIFF
--- a/home/desktop.nix
+++ b/home/desktop.nix
@@ -181,7 +181,6 @@
         substituteInPlace extracted_Bibata-Modern-Ice/manifest.hl \
           --replace-fail "name = Extracted Theme" "name = Bibata-Modern-Ice"
         hyprcursor-util --create extracted_Bibata-Modern-Ice --output .
-        mkdir -p "$out"
-        cp -r "theme_Bibata-Modern-Ice/." "$out/"
+        cp -r theme_Bibata-Modern-Ice "$out"
       '';
 }

--- a/home/desktop.nix
+++ b/home/desktop.nix
@@ -149,38 +149,8 @@
   home.pointerCursor = {
     gtk.enable = true;
     # x11.enable = true;
-    # Hyprland 0.55 uses hyprcursor by default, but bibata-cursors ships only an
-    # XCursor theme, so Hyprland can't resolve Bibata and falls back to a generic
-    # default cursor. Enabling hyprcursor here exports HYPRCURSOR_THEME/SIZE so
-    # Hyprland looks for a hyprcursor theme named "Bibata-Modern-Ice" (this
-    # home-manager version only sets the env vars; the theme itself is generated
-    # from the XCursor theme in the xdg.dataFile entry below).
-    hyprcursor.enable = true;
     package = pkgs.bibata-cursors;
     name = "Bibata-Modern-Ice";
     size = 24;
   };
-
-  # bibata-cursors is XCursor-only, so convert it to hyprcursor format for
-  # Hyprland 0.55 (which defaults to hyprcursor). hyprcursor-util --extract
-  # decompiles the XCursor theme (needs xcur2png) and --create compiles a
-  # hyprcursor theme. The manifest name is set to "Bibata-Modern-Ice" so
-  # Hyprland resolves HYPRCURSOR_THEME to this theme (hyprcursor matches on the
-  # manifest name or the directory stem). Installed under ~/.local/share/icons,
-  # which libhyprcursor searches; the XCursor theme keeps its own dir untouched.
-  xdg.dataFile."icons/Bibata-Modern-Ice-hyprcursor".source =
-    pkgs.runCommand "bibata-modern-ice-hyprcursor"
-      {
-        nativeBuildInputs = [
-          pkgs.hyprcursor
-          pkgs.xcur2png
-        ];
-      }
-      ''
-        hyprcursor-util --extract ${pkgs.bibata-cursors}/share/icons/Bibata-Modern-Ice --output .
-        substituteInPlace extracted_Bibata-Modern-Ice/manifest.hl \
-          --replace-fail "name = Extracted Theme" "name = Bibata-Modern-Ice"
-        hyprcursor-util --create extracted_Bibata-Modern-Ice --output .
-        cp -r theme_Bibata-Modern-Ice "$out"
-      '';
 }

--- a/home/desktop.nix
+++ b/home/desktop.nix
@@ -149,8 +149,39 @@
   home.pointerCursor = {
     gtk.enable = true;
     # x11.enable = true;
+    # Hyprland 0.55 uses hyprcursor by default, but bibata-cursors ships only an
+    # XCursor theme, so Hyprland can't resolve Bibata and falls back to a generic
+    # default cursor. Enabling hyprcursor here exports HYPRCURSOR_THEME/SIZE so
+    # Hyprland looks for a hyprcursor theme named "Bibata-Modern-Ice" (this
+    # home-manager version only sets the env vars; the theme itself is generated
+    # from the XCursor theme in the xdg.dataFile entry below).
+    hyprcursor.enable = true;
     package = pkgs.bibata-cursors;
     name = "Bibata-Modern-Ice";
     size = 24;
   };
+
+  # bibata-cursors is XCursor-only, so convert it to hyprcursor format for
+  # Hyprland 0.55 (which defaults to hyprcursor). hyprcursor-util --extract
+  # decompiles the XCursor theme (needs xcur2png) and --create compiles a
+  # hyprcursor theme. The manifest name is set to "Bibata-Modern-Ice" so
+  # Hyprland resolves HYPRCURSOR_THEME to this theme (hyprcursor matches on the
+  # manifest name or the directory stem). Installed under ~/.local/share/icons,
+  # which libhyprcursor searches; the XCursor theme keeps its own dir untouched.
+  xdg.dataFile."icons/Bibata-Modern-Ice-hyprcursor".source =
+    pkgs.runCommand "bibata-modern-ice-hyprcursor"
+      {
+        nativeBuildInputs = [
+          pkgs.hyprcursor
+          pkgs.xcur2png
+        ];
+      }
+      ''
+        hyprcursor-util --extract ${pkgs.bibata-cursors}/share/icons/Bibata-Modern-Ice --output .
+        substituteInPlace extracted_Bibata-Modern-Ice/manifest.hl \
+          --replace-fail "name = Extracted Theme" "name = Bibata-Modern-Ice"
+        hyprcursor-util --create extracted_Bibata-Modern-Ice --output .
+        mkdir -p "$out"
+        cp -r "theme_Bibata-Modern-Ice/." "$out/"
+      '';
 }

--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -175,9 +175,19 @@
       };
 
       # --- Cursor ---
+      # Hyprland 0.55 defaults to hyprcursor, but Bibata ships only an XCursor
+      # theme, so Hyprland finds no hyprcursor theme and falls back to a generic
+      # cursor. Disable hyprcursor and name the already-installed Bibata XCursor
+      # theme (via the env vars below) to restore the pre-upgrade cursor.
       cursor = {
         no_hardware_cursors = true;
+        enable_hyprcursor = false;
       };
+
+      env = [
+        "XCURSOR_THEME,Bibata-Modern-Ice"
+        "XCURSOR_SIZE,24"
+      ];
 
       # --- Layer Rules ---
       layerrule = [


### PR DESCRIPTION
## Problem

After a reboot activated a system upgrade, the mouse cursor changed to a generic default cursor.

**Root cause:** classic-laddie runs Hyprland 0.55, which defaults to **hyprcursor**. The configured cursor (`bibata-cursors` / `Bibata-Modern-Ice`) ships **only as an XCursor theme**, so Hyprland finds no hyprcursor theme and falls back to a generic default. On top of that, `XCURSOR_THEME` was never exported in the session, so even Hyprland's XCursor fallback had no theme name to load.

## Fix

Minimal, config-only — nothing is generated. The Bibata XCursor theme is already installed and on `XCURSOR_PATH`.

In `home/hyprland.nix`:
- `cursor.enable_hyprcursor = false` — tell Hyprland to use XCursor instead of hyprcursor.
- Export the theme name/size via Hyprland's `env`:
  - `XCURSOR_THEME,Bibata-Modern-Ice`
  - `XCURSOR_SIZE,24`

This replaces an earlier approach that ran `hyprcursor-util` to generate a hyprcursor theme in a derivation, per the maintainer's request to minimize config. `home/desktop.nix` is unchanged vs `main` (net-zero diff); `home.pointerCursor` stays as-is since it's still useful for GTK apps.

## Validation

- `nix eval` of the generated Hyprland settings confirms the values land:
  - `cursor: {"enable_hyprcursor": false, "no_hardware_cursors": true}`
  - `env: ["XCURSOR_THEME,Bibata-Modern-Ice", "XCURSOR_SIZE,24"]`
- Pre-commit hooks (`nixfmt`, `detect-private-keys`) pass.

Note: the full toplevel build currently fails on an unrelated pre-existing issue — `python3.14-catppuccin` (a dependency of `catppuccin-gtk`) fails to build due to a matplotlib packaging bug in the pinned nixpkgs. This is not affected by this change and fails identically on `main`.

## After rebuild

Re-login, or run `hyprctl setcursor Bibata-Modern-Ice 24`, for the cursor to take effect in the running session.