### PR TITLE
classic-laddie: fix auto-rebuild-on-push (polkit grant for github-relay)

### DIFF
--- a/hosts/classic-laddie/default.nix
+++ b/hosts/classic-laddie/default.nix
@@ -216,6 +216,39 @@ in
     };
   };
 
+  # The relay's systemd action execs `systemctl start <unit>` as the service
+  # user, which needs polkit's org.freedesktop.systemd1.manage-units. The
+  # upstream module runs with DynamicUser, whose UID is allocated at service
+  # start — polkit rules can't reliably match it — so pin a static system
+  # user here and grant it exactly one verb on exactly one unit below. The
+  # module's explicit sandboxing (ProtectSystem=strict, NoNewPrivileges, ...)
+  # is unaffected.
+  users.users.github-relay = {
+    isSystemUser = true;
+    group = "github-relay";
+  };
+  users.groups.github-relay = { };
+  systemd.services.github-relay.serviceConfig = {
+    DynamicUser = lib.mkForce false;
+    User = "github-relay";
+    Group = "github-relay";
+  };
+
+  # Least-privilege grant for the rebuild dispatch: github-relay may start
+  # cosmo-rebuild.service and nothing else. Without this, polkit denies
+  # manage-units to unprivileged callers ("interactive authentication
+  # required") and every push dispatch fails.
+  security.polkit.extraConfig = ''
+    polkit.addRule(function(action, subject) {
+      if (action.id == "org.freedesktop.systemd1.manage-units" &&
+          action.lookup("unit") == "cosmo-rebuild.service" &&
+          action.lookup("verb") == "start" &&
+          subject.user == "github-relay") {
+        return polkit.Result.YES;
+      }
+    });
+  '';
+
   # ---------------------------------------------------------------------------
   # Valley host: bare-git hosting (the-valley oc-9949561, Phase 0)
   # ---------------------------------------------------------------------------
@@ -256,11 +289,15 @@ in
   # ---------------------------------------------------------------------------
   systemd.services.cosmo-rebuild = {
     description = "Rebuild NixOS from cosmo main";
+    # StartLimit* are [Unit] keys; in [Service] systemd ignores them and the
+    # rate limit silently never applies.
+    unitConfig = {
+      StartLimitIntervalSec = 300;
+      StartLimitBurst = 3;
+    };
     serviceConfig = {
       Type = "oneshot";
       TimeoutStartSec = 600;
-      StartLimitIntervalSec = 300;
-      StartLimitBurst = 3;
       # Build subprocesses inherit this unit's cgroup, so the caps actually
       # constrain the rebuild — unlike daemon-targeted limits, which don't
       # apply when nixos-rebuild runs the build directly in its own process


### PR DESCRIPTION
## Problem

The auto-rebuild-on-push loop on classic-laddie has never worked. The `cosmo-rebuild` consumer in github-relay dispatches `systemctl start cosmo-rebuild` on every push to cosmo main, but every dispatch fails:

```
github-relay[3964]: ERROR 'dispatch failed' consumer=cosmo-rebuild action=systemd error='systemctl start cosmo-rebuild: exit status 1: Failed to start cosmo-rebuild.service: Access denied as the requested operation requires interactive authentication. However, interactive authentication has not been enabled by the calling program.'
```

Root cause: the upstream github-relay module runs the service with `DynamicUser=true`, and polkit denies `org.freedesktop.systemd1.manage-units` to unprivileged callers without interactive auth.

## Fix (cosmo-only, least privilege)

- **Pin the relay to a static system user.** The relay binary execs `systemctl start <unit>` directly (verified against the locked input rev `62e15a5`, identical to `~/hack/github-relay` HEAD), so a sudoers rule would never be consulted, and a polkit rule can't reliably match a `DynamicUser` (the UID is allocated at service start). cosmo overrides the unit with `DynamicUser=false` + `User=github-relay` (`lib.mkForce`). All of the module's sandboxing (`ProtectSystem=strict`, `NoNewPrivileges`, `PrivateTmp`, `ProtectHome`, `ReadOnlyPaths=/`) is set explicitly in the upstream unit, so none of it is lost, and `services.tailscale.permitCertUid = "github-relay"` still matches by name.
- **Narrow polkit rule** via `security.polkit.extraConfig`: allow action `org.freedesktop.systemd1.manage-units` only when `unit == "cosmo-rebuild.service"`, `verb == "start"`, and `subject.user == "github-relay"`. No blanket manage-units grant.

## Also fixed (same unit)

`StartLimitIntervalSec`/`StartLimitBurst` were in `serviceConfig`, but they are `[Unit]` keys — the journal showed `Unknown key StartLimitIntervalSec in section [Service], ignoring`, so the rate limit never applied. Moved to `unitConfig`.

## Verification

- `nix flake check` — all checks passed
- `nix eval .#nixosConfigurations.classic-laddie.config.system.build.toplevel.drvPath` — evaluates cleanly
- Rendered artifacts from the eval prove the fix is in the closure:
  - `systemd.units."cosmo-rebuild.service".text` now has `StartLimitBurst=3` / `StartLimitIntervalSec=300` under `[Unit]` (gone from `[Service]`)
  - `environment.etc."polkit-1/rules.d/10-nixos.rules".text` contains the scoped rule
  - `systemd.units."github-relay.service".text` shows `DynamicUser=false`, `User=github-relay`, `Group=github-relay`

## Deploy note — one manual step required

This fix only takes effect after the **next successful rebuild** on classic-laddie. The currently-running system still denies the dispatch, so the first deploy after merging needs a manual `sudo systemctl start cosmo-rebuild` (or `nixos-rebuild switch`) on classic-laddie. After that one activation, the push→rebuild loop is self-sustaining.

Run: 20260711-1657-1d8eb375