### PR TITLE
desktop: fix catppuccin-gtk build on python 3.14 / matplotlib 3.11

### DIFF
--- a/modules/common/desktop.nix
+++ b/modules/common/desktop.nix
@@ -6,6 +6,40 @@
 }:
 
 {
+  # --- catppuccin-gtk build fix (temporary) ---
+  # python3.14-catppuccin-2.5.0 (dependency of catppuccin-gtk, used for GTK
+  # theming in home/desktop.nix) fails its check phase: matplotlib 3.11
+  # removed mpl.style.core, which catppuccin 2.5.0's matplotlib extra still
+  # calls (catppuccin/python#129). This breaks every desktop host's system
+  # build. Mirror the two nixpkgs-master fixes that are not yet on the
+  # pinned nixos-unstable channel:
+  #   455d916d0c python3Packages.catppuccin: fix build with matplotlib 3.11+
+  #               (patch from catppuccin/python#130)
+  #   894acc94f6 catppuccin-gtk: fix build with python314+
+  # Remove this overlay once the nixpkgs pin includes both commits — the
+  # daily flake.lock update should bring them within days.
+  nixpkgs.overlays = [
+    (final: prev: {
+      catppuccin-gtk =
+        (prev.catppuccin-gtk.override {
+          python3 = prev.python3.override {
+            packageOverrides = pyfinal: pyprev: {
+              catppuccin = pyprev.catppuccin.overridePythonAttrs (old: {
+                patches = (old.patches or [ ]) ++ [
+                  ./patches/catppuccin-python-matplotlib-3.11.patch
+                ];
+              });
+            };
+          };
+        }).overrideAttrs
+          (old: {
+            patches = (old.patches or [ ]) ++ [
+              ./patches/catppuccin-gtk-python-3.14.patch
+            ];
+          });
+    })
+  ];
+
   # --- Desktop Environment ---
   programs.hyprland = {
     enable = true;

--- a/modules/common/patches/catppuccin-gtk-python-3.14.patch
+++ b/modules/common/patches/catppuccin-gtk-python-3.14.patch
@@ -1,0 +1,20 @@
+diff --git a/sources/build/args.py b/sources/build/args.py
+index 38a0a12..9221dec 100644
+--- a/sources/build/args.py
++++ b/sources/build/args.py
+@@ -84,7 +84,6 @@ def parse_args():
+     parser.add_argument(
+         "--zip",
+         help="Whether to bundle the theme into a zip",
+-        type=bool,
+         default=False,
+         action=argparse.BooleanOptionalAction,
+     )
+@@ -92,7 +91,6 @@ def parse_args():
+     parser.add_argument(
+         "--patch",
+         help="Whether to patch the colloid submodule",
+-        type=bool,
+         default=True,
+         action=argparse.BooleanOptionalAction,
+     )

--- a/modules/common/patches/catppuccin-python-matplotlib-3.11.patch
+++ b/modules/common/patches/catppuccin-python-matplotlib-3.11.patch
@@ -1,0 +1,37 @@
+From 11ab7be947064f11453f1063f63455b343b7253d Mon Sep 17 00:00:00 2001
+From: Raziman T V <razimantv@gmail.com>
+Date: Fri, 3 Jul 2026 13:36:29 +0100
+Subject: [PATCH] Fix #129 (caused by matplotlib 3.11 deprecating
+ mpl.style.core) by direct implementation
+
+---
+ catppuccin/extras/matplotlib.py | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/catppuccin/extras/matplotlib.py b/catppuccin/extras/matplotlib.py
+index 52934d1..f0ffafb 100644
+--- a/catppuccin/extras/matplotlib.py
++++ b/catppuccin/extras/matplotlib.py
+@@ -72,6 +72,7 @@
+ import matplotlib as mpl
+ import matplotlib.colors
+ import matplotlib.style
++from matplotlib import rc_params_from_file
+ 
+ from catppuccin.palette import PALETTE
+ 
+@@ -84,10 +85,10 @@
+ 
+ def _register_styles() -> None:
+     """Register the included stylesheets in the mpl style library."""
+-    catppuccin_stylesheets = mpl.style.core.read_style_directory(  # type: ignore [attr-defined]
+-        CATPPUCCIN_STYLE_DIRECTORY
+-    )
+-    mpl.style.core.update_nested_dict(mpl.style.library, catppuccin_stylesheets)  # type: ignore [attr-defined]
++    for path in Path(CATPPUCCIN_STYLE_DIRECTORY).glob(f"*.mplstyle"):
++        stylename = path.stem
++        style = rc_params_from_file(path, use_default_template=False)
++        mpl.style.library.setdefault(stylename, {}).update(style)
+ 
+ 
+ def _register_colormap_list() -> None:


### PR DESCRIPTION
## Root cause

classic-laddie's system build is broken on main: `python3.14-catppuccin-2.5.0` (a dependency of `catppuccin-gtk-1.0.3`, used for GTK theming in `home/desktop.nix`) fails its check phase with:

```
AttributeError: module 'matplotlib.style' has no attribute 'core'
```

matplotlib 3.11 removed `mpl.style.core`; catppuccin 2.5.0's matplotlib extra still calls it at import time (upstream issue: catppuccin/python#129, fixed by catppuccin/python#130). This blocks all deploys on classic-laddie (and would break weller/johnny-walker the same way).

## Fix

nixpkgs master already fixed this, but the pinned nixos-unstable channel hasn't caught up yet. This PR mirrors the two master commits locally via a `nixpkgs.overlays` entry in `modules/common/desktop.nix`:

- [`455d916d0c`](https://github.com/NixOS/nixpkgs/commit/455d916d0c1750d67b097386947fc52d1bb2f28d) `python3Packages.catppuccin: fix build with matplotlib 3.11+` — applies the catppuccin/python#130 patch to the python `catppuccin` library (the actual failing derivation), routed through catppuccin-gtk's `python3` argument so nothing else rebuilds.
- [`894acc94f6`](https://github.com/NixOS/nixpkgs/commit/894acc94f63aae4b9483cf5d9f64c183398e2454) `catppuccin-gtk: fix build with python314+` — patches catppuccin-gtk's `sources/build/args.py` (argparse `type=bool` + `BooleanOptionalAction` is an error on python 3.14), the next failure once the python lib builds.

Both patch files are verbatim copies from those nixpkgs commits. The overlay is temporary: remove it once the nixpkgs pin includes both commits — the daily flake.lock update should bring them within days (a comment in the overlay says the same).

## Verification

- `nix build .#nixosConfigurations.classic-laddie.config.system.build.toplevel --no-link` — **full local toplevel build succeeded** (note: CI only dry-runs evaluation, so this is stated explicitly here; the patched `catppuccin-gtk-1.0.3` built and is in the closure).
- `nix flake check` — all checks passed.
- `klaus _pre-review` — no issues found.

## Deploy note

After merge, someone needs to run `sudo systemctl start cosmo-rebuild` once on classic-laddie to bootstrap the auto-rebuild loop (see #613).

Run: 20260712-0926-0fc6e840