### PR TITLE
classic-laddie: declare qinling project on the valley host

### DIFF
--- a/hosts/classic-laddie/valley.cue
+++ b/hosts/classic-laddie/valley.cue
@@ -17,6 +17,14 @@ projects: {
 	"the-valley": {
 		mirrors: ["git@github.com:gunk-dev/the-valley.git"]
 	}
+
+	// The gunk-dev valley *instance* repo — this instance's own declaration,
+	// runbook, and operational outcomes. Born sovereign: canonical origin is
+	// this host, deliberately no mirrors yet — a GitHub mirror gets declared
+	// once cosmo consumes the instance declaration as a flake input and CI
+	// needs a fetchable copy. Named for Qinling, the valley range associated
+	// with the Tao Te Ching's origin.
+	"qinling": {}
 }
 
 // The host's durability policy (the-valley's #Backup): nightly restic to


### PR DESCRIPTION
Declares a second project, `qinling`, on classic-laddie's valley host (`hosts/classic-laddie/valley.cue`).

## What qinling is

Per the owner's decision, qinling is the gunk-dev valley *instance* repo: the instance's own declaration, runbook, and operational outcomes. It is born sovereign — the canonical origin is this host, and it deliberately has **no mirrors yet**. A GitHub mirror gets declared later, when cosmo consumes the instance declaration as a flake input and CI needs a fetchable copy. The name is Qinling, the valley range associated with the Tao Te Ching's origin.

The empty project value is valid against the-valley's schema: `git.enable` defaults to true and `mirrors` defaults to `[]`.

## What merging does

Merging auto-deploys via the now-working cosmo rebuild loop, and valley-init creates the empty bare repo `git@classic-laddie:qinling.git`. Content seeding follows as a separate step in S1 direct-push mode.

## Validation

- `cue vet -c` against the-valley's schema at cosmo's locked rev (`bd4d261`): passes
- `nix flake check`: all checks pass
- `nix eval .#nixosConfigurations.classic-laddie.config.system.build.toplevel.drvPath`: evaluates cleanly

Note: `klaus _pre-review` flagged a missing `Path` import in `catppuccin-python-matplotlib-3.11.patch`, but that file is already-merged code from #618 (the local main ref was stale) and the finding is a false positive — the upstream file imports `Path` at line 69, outside the patch hunk's context.

Run: 20260712-1019-57c27772