### PR TITLE
classic-laddie: fix restic sftp URL example in valley backup runbook

### DIFF
--- a/hosts/classic-laddie/default.nix
+++ b/hosts/classic-laddie/default.nix
@@ -302,7 +302,10 @@ in
   #   3. Populate the secrets:
   #        cd secrets && agenix -e valley-restic-repo.age
   #          # single line, the restic repository URL, e.g.:
-  #          # sftp://u123456@u123456.your-storagebox.de:23//./backups/valley
+  #          # sftp://u123456@u123456.your-storagebox.de:23//home/backups/valley
+  #          # (the path must live under /home — the sftp account lands in
+  #          # /home and the box root is not writable, so a root-anchored
+  #          # path fails restic init with a generic SSH_FX_FAILURE)
   #        cd secrets && agenix -e valley-restic-password.age
   #          # single line, the restic repository encryption password
   #          # (generate one and store it in the password manager — losing it


### PR DESCRIPTION
Initializing the valley restic repository today failed with a generic `sftp Failure (SSH_FX_FAILURE)` on MkdirAll because the runbook's example URL used the root-anchored form `//./backups/valley` — on Hetzner Storage Boxes the sftp account lands in /home and the box root is read-only. This corrects the example to `//home/backups/valley` and adds a short note explaining why, so the next person doesn't hit the same opaque error.

Run: 20260712-1706-47fd26a4