### PR TITLE
classic-laddie: make cosmo-rebuild level-triggered with a reconcile timer

### DIFF
--- a/hosts/classic-laddie/default.nix
+++ b/hosts/classic-laddie/default.nix
@@ -348,6 +348,11 @@ in
   # the hourly timer bounds any remaining gap.
   systemd.services.cosmo-rebuild = {
     description = "Converge NixOS to the tip of cosmo main";
+    # The switch this unit runs may change this very unit; without these,
+    # activation would stop/restart it mid-flight, killing the rebuild it's
+    # performing (same reason nixos-upgrade.service sets restartIfChanged).
+    restartIfChanged = false;
+    stopIfChanged = false;
     # StartLimit* are [Unit] keys; in [Service] systemd ignores them and the
     # rate limit silently never applies.
     unitConfig = {

--- a/hosts/classic-laddie/default.nix
+++ b/hosts/classic-laddie/default.nix
@@ -337,8 +337,17 @@ in
   # ---------------------------------------------------------------------------
   # Auto-rebuild on push to cosmo main
   # ---------------------------------------------------------------------------
+  # Level-triggered convergence, not edge-triggered dispatch: a run converges
+  # the machine to whatever the remote tip is *now*, instead of treating each
+  # webhook as "do one rebuild". Edge-triggering lost events in practice: a
+  # push landing while a rebuild ran made the relay's re-dispatch block on the
+  # active unit (`systemctl start` waits for oneshot units) until the relay's
+  # exec timeout killed it, leaving main ahead of the deployed system with
+  # nothing scheduled to reconcile. With the loop below a lost start signal
+  # costs nothing — the running unit re-checks the tip after each switch, and
+  # the hourly timer bounds any remaining gap.
   systemd.services.cosmo-rebuild = {
-    description = "Rebuild NixOS from cosmo main";
+    description = "Converge NixOS to the tip of cosmo main";
     # StartLimit* are [Unit] keys; in [Service] systemd ignores them and the
     # rate limit silently never applies.
     unitConfig = {
@@ -347,7 +356,13 @@ in
     };
     serviceConfig = {
       Type = "oneshot";
-      TimeoutStartSec = 600;
+      # One run may now perform several switches (the converge loop), so the
+      # timeout covers the loop bound, not a single switch as before.
+      TimeoutStartSec = 3600;
+      # /var/lib/cosmo-rebuild/deployed-rev records the last rev that
+      # *successfully switched*; the early exit against it makes a no-change
+      # run cost one git ls-remote.
+      StateDirectory = "cosmo-rebuild";
       # Build subprocesses inherit this unit's cgroup, so the caps actually
       # constrain the rebuild — unlike daemon-targeted limits, which don't
       # apply when nixos-rebuild runs the build directly in its own process
@@ -362,8 +377,62 @@ in
       nix
     ];
     script = ''
-      nixos-rebuild switch --no-write-lock-file --refresh --flake github:patflynn/cosmo#classic-laddie
+      # The wrapper already runs bash -e; pipefail on top so a failed
+      # ls-remote isn't masked by cut exiting 0.
+      set -o pipefail
+
+      state_file="''${STATE_DIRECTORY}/deployed-rev"
+
+      for _ in 1 2 3 4 5; do
+        # Resolve the tip first, then deploy exactly that rev — what we
+        # compare is what we switch to. If ls-remote fails (network down,
+        # GitHub unreachable) the unit fails here, cleanly, without touching
+        # the state file; the timer retries within the hour.
+        rev=$(git ls-remote https://github.com/patflynn/cosmo.git refs/heads/main | cut -f1)
+        if [ -z "$rev" ]; then
+          echo "could not resolve refs/heads/main on the remote" >&2
+          exit 1
+        fi
+
+        # First run: no state file, $deployed stays empty, never equals $rev,
+        # so we proceed to deploy.
+        deployed=""
+        if [ -f "$state_file" ]; then
+          deployed=$(cat "$state_file")
+        fi
+
+        if [ "$rev" = "$deployed" ]; then
+          echo "already at tip $rev"
+          exit 0
+        fi
+
+        echo "deploying $rev (previously deployed: ''${deployed:-<none>})"
+        nixos-rebuild switch --no-write-lock-file --flake "github:patflynn/cosmo/$rev#classic-laddie"
+
+        # Reached only when the switch succeeded (bash -e aborts above
+        # otherwise): the state file holds successfully deployed revs, never
+        # attempts, so a failed deploy is retried from scratch next run.
+        echo "$rev" > "$state_file"
+
+        # Loop: main may have moved while the build ran — converge again.
+      done
+
+      echo "main moved during all 5 converge iterations; leaving the rest to the next run" >&2
     '';
+  };
+
+  # Reconcile timer, belt-and-braces to the webhook: even if a push event is
+  # lost entirely (relay down, network blip, or the small race between the
+  # loop's final tip check and unit exit), the machine converges within
+  # roughly an hour. The early exit in the script keeps the steady-state cost
+  # at one git ls-remote per tick.
+  systemd.timers.cosmo-rebuild = {
+    wantedBy = [ "timers.target" ];
+    timerConfig = {
+      OnCalendar = "hourly";
+      RandomizedDelaySec = "5m";
+      Persistent = true;
+    };
   };
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

cosmo-rebuild was edge-triggered: each webhook meant "do one rebuild of whatever main is right now". That lost a real event this week — a push landed on main while a rebuild (triggered by the previous push) was still running. `systemctl start` blocks on an active oneshot unit, so the relay's re-dispatch hung until the relay's exec timeout killed it (`systemctl start: signal: killed`), and the push event was gone. main sat ahead of the deployed system with nothing scheduled to reconcile.

## Fix: converge to tip instead of reacting to events

The unit no longer treats a start signal as a command to build; a start signal (webhook or timer) just means "make sure the machine matches the tip of main now". In wu-wei terms: the unit stops chasing events and instead lets the system settle to the declared state whenever it's poked. Concretely, the script is now a loop:

1. Resolve the remote tip: `git ls-remote https://github.com/patflynn/cosmo.git refs/heads/main`.
2. Compare against the last **successfully deployed** rev, kept in `/var/lib/cosmo-rebuild/deployed-rev` (`StateDirectory=cosmo-rebuild`). Equal → log `already at tip <rev>`, exit 0. This makes periodic reconciliation nearly free.
3. Otherwise `nixos-rebuild switch --no-write-lock-file --flake "github:patflynn/cosmo/$rev#classic-laddie"` — the exact rev that was compared is the rev that gets deployed (`github:owner/repo/rev` is standard flake-ref syntax; verified below). `--refresh` is dropped: it existed to defeat tarball caching on a branch ref, which a pinned rev doesn't need.
4. On success, record `$rev` in the state file and **loop back to 1** — if main moved during the build, the same run converges again. Bounded at 5 iterations with a log line if the bound is hit (the next run picks up from there).

Because a running unit re-checks the tip after each switch, a start request that gets coalesced or killed while the unit is active no longer loses anything — the in-flight run will see the new commit itself.

Edge cases handled in the script (with comments):
- `git ls-remote` failing (network down) fails the unit cleanly without touching the state file; `set -o pipefail` on top of the wrapper's `bash -e` so `cut` can't mask it.
- First run with no state file: `deployed` stays empty, never equals the tip, so it proceeds to deploy.
- The state file only ever records revs that switched successfully — a failed switch aborts before the write and the whole rev is retried next run.

`TimeoutStartSec` goes 600 → 3600 since one run may now perform several switches. `StartLimit*` stay in `unitConfig` (they're `[Unit]` keys, per #613), and the resource caps (`MemoryHigh=80%`, idle CPU/IO scheduling) are unchanged.

## Reconcile timer

Belt-and-braces for the webhook path:

```
[Timer]
OnCalendar=hourly
Persistent=true
RandomizedDelaySec=5m
```

There is still a tiny race by construction: a push that lands after the loop's final `ls-remote` check but before the unit exits is invisible to that run, and its webhook may be swallowed by the same blocked-start behavior. The timer is what bounds that window — worst case the machine is behind by about an hour, instead of indefinitely. The step-2 early exit keeps the steady-state cost of a timer tick at a single `git ls-remote`.

## Verification

- `nix flake check` — all checks passed.
- `nix eval .#nixosConfigurations.classic-laddie.config.system.build.toplevel.drvPath` → `/nix/store/zmf4pgag1l5a3libi9vy15yj81ha775x-nixos-system-classic-laddie-26.11.20260711.e7a3ca8.drv`.
- Rendered `cosmo-rebuild.service` from the eval (excerpt):
  ```
  [Service]
  ...
  ExecStart=/nix/store/xcvs...-unit-script-cosmo-rebuild-start/bin/cosmo-rebuild-start
  MemoryHigh=80%
  StateDirectory=cosmo-rebuild
  TimeoutStartSec=3600
  Type=oneshot
  ```
  and the generated start script contains the converge loop:
  ```
  for _ in 1 2 3 4 5; do
    rev=$(git ls-remote https://github.com/patflynn/cosmo.git refs/heads/main | cut -f1)
    ...
    if [ "$rev" = "$deployed" ]; then
      echo "already at tip $rev"
      exit 0
    fi
    ...
    nixos-rebuild switch --no-write-lock-file --flake "github:patflynn/cosmo/$rev#classic-laddie"
    echo "$rev" > "$state_file"
  done
  ```
- Rev-pinned flake ref resolves: `nix flake metadata github:patflynn/cosmo/f17a9ce20ec5e3a8f07ad616ffeb964aded55bca` → resolves to exactly that revision.
- `klaus _pre-review` — no issues.

Note for rollout: as with #613, the new unit/timer only take effect once this is deployed, so the first converge after merge needs the usual manual `sudo systemctl start cosmo-rebuild` on classic-laddie (that run will also enable the timer via the new generation).

Run: 20260712-1716-8de39c03