### PR TITLE
flake.lock: bump the-valley for mirror-push refspec fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -439,11 +439,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783890641,
-        "narHash": "sha256-QW9M2IbRdWyBKab7IVyvyUxnuKrV9VqHdofZfSHYBfs=",
+        "lastModified": 1783950630,
+        "narHash": "sha256-OypsF18QHZs3XPrXzjBDIiziNWgV5uhMmYEazvCqHpA=",
         "owner": "gunk-dev",
         "repo": "the-valley",
-        "rev": "79a3e64d889df44f972fb8f8ea24d9ea7b2433f7",
+        "rev": "74b89958d5f639799f08141b6da67d60deaac6a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps the `the-valley` input from `79a3e64` to `74b8995` (current main tip) to pick up gunk-dev/the-valley#18, which fixes the valley-host post-receive mirror hook: instead of `git push --mirror` — which also tries to propagate ephemeral refs like `refs/pull/*` and fails against GitHub — the hook now pushes explicit `+refs/heads/*` and `+refs/tags/*` refspecs with `--prune`, keeping the same branch/tag force-update and deletion semantics. Verified the locked rev matches `refs/heads/main` upstream and that its `nix/valley-host.nix` contains the new `push --prune` invocation with no `git push --mirror`; `nix flake check` passes and `classic-laddie`'s toplevel evaluates. The cosmo-rebuild converge loop deploys this to classic-laddie on merge, clearing the way for populating the-valley's primary on the valley host (migration Phase 1).

Run: 20260713-0950-f4da1cd0