### PR TITLE
home/dev: install the valley CLI from the-valley input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -439,11 +439,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783950630,
-        "narHash": "sha256-OypsF18QHZs3XPrXzjBDIiziNWgV5uhMmYEazvCqHpA=",
+        "lastModified": 1783986223,
+        "narHash": "sha256-e6rsdhhtBEbOlN5TybtrVsXp+tgjPnyxAHhHF4MSUF8=",
         "owner": "gunk-dev",
         "repo": "the-valley",
-        "rev": "74b89958d5f639799f08141b6da67d60deaac6a2",
+        "rev": "d833cf8bbe02388d4936c0d536a36685c1ee683a",
         "type": "github"
       },
       "original": {

--- a/home/dev.nix
+++ b/home/dev.nix
@@ -85,6 +85,9 @@
 
         # Agent orchestration
         inputs.klaus.packages."${pkgs.stdenv.hostPlatform.system}".default
+
+        # the valley CLI (S1 integrator verbs: pending/review); ships from the engine repo
+        inputs.the-valley.packages."${pkgs.stdenv.hostPlatform.system}".valley
       ]
       ++ lib.optional config.cosmo.antigravity.enable pkgs.antigravity;
 


### PR DESCRIPTION
Bumps the-valley to current main (d833cf8) and adds the new valley CLI (S1 integrator verbs: pending/review) to the owner's dev profile in home/dev.nix. The cosmo-rebuild converge loop on classic-laddie deploys it automatically on merge.

Run: 20260713-1950-4ae0196f