### PR TITLE
home/dev: add delta pager and difftastic second-opinion diff

### DIFF
--- a/home/dev.nix
+++ b/home/dev.nix
@@ -79,6 +79,7 @@
         claude-code # Anthropic's CLI
         github-cli # GitHub CLI (gh)
         jujutsu # Modern VCS (jj)
+        difftastic # Structural diff (difft), wired to the `git dft` alias below
 
         # Age tools
         inputs.agenix.packages."${pkgs.stdenv.hostPlatform.system}".default
@@ -94,6 +95,21 @@
     programs.zsh.shellAliases = {
       rebuild = "if [ -e /etc/NIXOS ]; then sudo nixos-rebuild switch --flake .; else nix run home-manager -- switch --flake .; fi";
     };
+
+    # Delta as git's pager for diff/log/show (home-manager's first-class
+    # module; programs.git.delta was renamed to programs.delta upstream).
+    programs.delta = {
+      enable = true;
+      enableGitIntegration = true;
+      options = {
+        navigate = true; # n/N jump between files in a diff
+        line-numbers = true;
+      };
+    };
+
+    # Structural second-opinion diff: `git dft` runs difftastic on demand
+    # without making it the default differ.
+    programs.git.settings.alias.dft = "-c diff.external=difft diff";
 
     # Klaus agent orchestration config
     home.file.".klaus/config.json".text = builtins.toJSON {


### PR DESCRIPTION
Enables delta as git's pager for diff/log/show in the dev profile via home-manager's first-class module — note the pinned home-manager renamed `programs.git.delta` to `programs.delta`, so this uses the current option path with `enableGitIntegration = true` plus minimal options (`navigate`, `line-numbers`). Also installs difftastic with a `git dft` alias (`-c diff.external=difft diff`) as an on-demand structural diff, leaving the default differ untouched.

Verified: `nix flake check` passes, `classic-laddie` toplevel and all four CI home configurations eval cleanly, and the rendered `git/config` shows delta as pager + the `dft` alias with no global `diff.external`.

Note: valley review will pick delta up automatically once the-valley's pager tweak (`git var GIT_PAGER`) lands — no config needed here.

`klaus _pre-review` reported zero findings both runs, but the command itself errors parsing its own reviewer output (reviewer appends a stray code fence after valid JSON) — a klaus bug worth fixing separately.

Run: 20260715-0847-f6ff17a7