### PR TITLE
classic-laddie: enable the valley event bus

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -440,11 +440,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784290691,
-        "narHash": "sha256-oNkyQBOCALrpxpRMMHIFj99guLF3gFvv133H0dkZ3yo=",
+        "lastModified": 1784290911,
+        "narHash": "sha256-5+/KU+FJ2rNzZi9TIZmTtP4z/6qmAgDGMwb0GRfFFzM=",
         "owner": "gunk-dev",
         "repo": "the-valley",
-        "rev": "61494b3aef9a2071eb5c5e6308a742589940477e",
+        "rev": "b5ae1571d4baada1331dff1f939a6f5edb212b84",
         "type": "github"
       },
       "original": {

--- a/hosts/classic-laddie/default.nix
+++ b/hosts/classic-laddie/default.nix
@@ -261,6 +261,11 @@ in
     # Host-level access by design: the same user keys that can decrypt
     # secrets can push/fetch every project.
     authorizedKeys = (import ../../secrets/keys.nix).users;
+    # Event bus (the-valley Phase 1): NATS JetStream feed of project ref
+    # updates. Localhost only (127.0.0.1:4222, the module default) — widening
+    # the listener is gated on bus authorization
+    # (the-valley .the-valley/bugs/bd-d853d9c-bus-unauthenticated.md).
+    bus.enable = true;
     # dataDir stays at the default /srv/git (root fs) for now. Moving it to a
     # dedicated tank/git ZFS dataset (as PR #601 planned) is a follow-up: the
     # dataset doesn't exist yet and the first deploy must not depend on it.


### PR DESCRIPTION
Enables the phase-1 valley event bus on classic-laddie, now that the-valley's event log has merged (rev b5ae157).

## Changes

- **Bump the-valley input** `61494b3` → `b5ae157`, picking up the new `services.valley.bus` options in `nix/valley-host.nix` (the auto-bump PR #651 hasn't merged yet; this supersedes it for the the-valley input).
- **`services.valley.bus.enable = true`** on classic-laddie. This starts a NATS JetStream server feeding project ref updates onto the bus.

## Security posture

⚠️ **This enables a new service on the host and needs personal operator approval — please do not auto-merge.**

- The bus listens on **127.0.0.1:4222 only** (the module default). `bus.listen` is deliberately left unset: the localhost-only default is the security review's posture, and widening the listener is gated on bus authorization (the-valley `.the-valley/bugs/bd-d853d9c-bus-unauthenticated.md`).

## Verification

- `nix build .#nixosConfigurations.classic-laddie.config.system.build.toplevel --dry-run` — evaluates cleanly; `nats-server` appears in the closure, confirming the bus service is actually enabled.
- `nix flake check` — all checks passed.
- `nixfmt --check` — clean.
- `klaus _pre-review` — reviewer returned no findings (its output-parsing hiccup is the known trailing-code-fence bug, not a review failure).

Run: 20260717-0823-5b8e0fdf