### PR TITLE
macos: self-source Nix in shell + install JetBrainsMono Nerd Font

### DIFF
--- a/docs/macos-setup.md
+++ b/docs/macos-setup.md
@@ -75,3 +75,37 @@ Home Manager on macOS will configure a native **Launchd Agent** (`org.nix-commun
 * You can check the logs of the background updater at:
   * `/tmp/cosmo-home-autoupgrade.out.log` (stdout)
   * `/tmp/cosmo-home-autoupgrade.err.log` (stderr)
+
+---
+
+## 6. Nix in the Terminal (Daemon & Shell)
+
+`nix`, `home-manager`, and everything this profile installs reach your shell through the **Nix multi-user profile** script at
+`/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh`.
+
+### The nix-daemon is owned by the installer, not Home Manager
+
+The build daemon is a **launchd _system_ daemon** (`system/org.nixos.nix-daemon`) installed and owned by the Nix installer (Determinate Systems). It runs as root and is **outside the scope of standalone Home Manager** — Home Manager runs entirely in your user account and cannot create, own, or restart a root-level daemon. Do not try to manage it from this flake, and do not switch this profile to `nix-darwin` just to gain control of it.
+
+### The shell self-sources Nix (survives macOS updates)
+
+macOS updates periodically overwrite `/etc/zshrc`, which is where the installer hooks the line that sources `nix-daemon.sh`. When that happens, a freshly opened terminal can lose `nix` from its `PATH`.
+
+To make this robust, `home/darwin.nix` adds an early guard to the Home-Manager-managed zsh init that re-sources the profile itself:
+
+```zsh
+if [ -e /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+  . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+fi
+```
+
+Because Home Manager owns `~/.zshrc`, this line is restored on every `home-manager switch` and keeps `nix`/`home-manager` on `PATH` in every interactive and login shell — even after a macOS update clobbers `/etc/zshrc`.
+
+### Verify / restart the daemon
+
+If Nix commands hang or report the daemon is unreachable, inspect and restart the **system** daemon (requires `sudo`):
+
+```bash
+sudo launchctl print system/org.nixos.nix-daemon
+sudo launchctl kickstart -k system/org.nixos.nix-daemon
+```

--- a/home/darwin.nix
+++ b/home/darwin.nix
@@ -1,7 +1,39 @@
-{ config, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 {
   imports = [ ./dev.nix ];
 
-  home.packages = [ pkgs.home-manager ];
+  home.packages = [
+    pkgs.home-manager
+
+    # JetBrainsMono Nerd Font, matching home/zed.nix (buffer_font_family) and
+    # home/waybar.nix ("JetBrainsMono Nerd Font"). On darwin, home-manager's
+    # targets/darwin/fonts.nix copies fonts found in home.packages into
+    # ~/Library/Fonts/HomeManager as real files (macOS ignores symlinked
+    # fonts), so adding the package here is all that's needed to make it
+    # available to macOS apps. Do NOT also link it via home.file — that path is
+    # managed by home-manager and a second mechanism would collide.
+    pkgs.nerd-fonts.jetbrains-mono
+  ];
+
+  # Standalone home-manager cannot manage the root-owned launchd nix-daemon
+  # (it belongs to the Nix installer, not home-manager), but it CAN make every
+  # interactive/login shell robustly re-source the Nix multi-user profile so
+  # nix/home-manager stay on PATH even after a macOS update overwrites
+  # /etc/zshrc (where the installer hooks nix-daemon.sh). mkOrder 400 runs this
+  # before common.nix's initContent (default order 1000) and work.nix's corp
+  # block (mkBefore = 500), so Nix is available for everything that follows.
+  programs.zsh.initContent = lib.mkOrder 400 ''
+    # Self-source the Nix multi-user profile so nix/home-manager survive macOS
+    # updates that clobber /etc/zshrc. The nix-daemon itself is a launchd
+    # *system* daemon owned by the Nix installer, not home-manager.
+    if [ -e /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+      . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+    fi
+  '';
 }


### PR DESCRIPTION
Two focused, darwin-scoped improvements to the macOS home-manager profile
(`paflynn@paflynn-mac`, baseModule `home/darwin.nix`). Both are confined to the
darwin profile; Linux/NixOS/WSL/Crostini configs are unaffected.

## 1. Make `nix` consistently available in the terminal

Standalone home-manager cannot manage the root-owned launchd `nix-daemon` — it
belongs to the Nix installer, not home-manager — so we do not (and should not)
install a LaunchDaemon or switch to nix-darwin. Instead the home-manager-managed
zsh init now robustly self-sources the Nix multi-user profile:

```zsh
if [ -e /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
  . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
fi
```

It is added via `lib.mkOrder 400` so it runs **before** `common.nix`'s
`initContent` (default order 1000) and `work.nix`'s corp block
(`lib.mkBefore` = 500), and merges cleanly rather than clobbering them. Because
home-manager owns `~/.zshrc`, this keeps `nix`/`home-manager` on `PATH` in every
interactive/login shell even after a macOS update overwrites `/etc/zshrc` (where
the installer normally hooks `nix-daemon.sh`). The repo configures no bash login
shell, so no bash guard was needed.

### Daemon caveat
The `nix-daemon` itself is a launchd **system** daemon
(`system/org.nixos.nix-daemon`) owned by the installer and running as root;
standalone home-manager runs in the user account and cannot create/own/restart
it. `docs/macos-setup.md` now documents this, explains the shell self-sourcing,
and gives the verify/restart commands:

```bash
sudo launchctl print system/org.nixos.nix-daemon
sudo launchctl kickstart -k system/org.nixos.nix-daemon
```

## 2. Install JetBrainsMono Nerd Font on macOS

Adds `pkgs.nerd-fonts.jetbrains-mono` (the split `nerd-fonts.*` namespace, since
nixpkgs is nixos-unstable) to `home.packages` on the darwin profile, matching
`home/zed.nix` (`buffer_font_family`) and `home/waybar.nix`
(`"JetBrainsMono Nerd Font"`).

The pinned home-manager (`abfad3d…`) auto-imports
`modules/targets/darwin/fonts.nix`, which copies fonts found in `home.packages`
into `~/Library/Fonts/HomeManager` as **real files** via `rsync -L` (macOS
ignores symlinked fonts). So adding the package is sufficient to make the font
usable by macOS apps — no explicit `home.file."Library/Fonts/…"` link is needed,
and adding one would collide with that home-manager-managed path.

## Verification performed (on a Linux agent)

- `nix fmt` (nixfmt-tree) — clean; only the two touched files changed.
- `nix build .#checks.x86_64-linux.pre-commit-check` — **Passed**
  (detect-private-keys, nixfmt, zizmor).
- `klaus _pre-review` — no issues.
- Evaluated the aarch64-darwin home config without forcing darwin builds:
  - `config.programs.zsh.initContent` merges in the correct order — the
    `nix-daemon.sh` source appears first, then the corp block, then
    `common.nix`'s `$HOME/bin` PATH line.
  - `config.home.packages` contains `nerd-fonts-jetbrains-mono-3.4.0+2.304`.
  - `config.home.file."Library/Fonts/.home-manager-fonts-version"` resolves to a
    `home-manager-fonts` env, confirming the darwin fonts module is active and
    will copy the font into `~/Library/Fonts/HomeManager`.
- Built the font package on this Linux agent
  (`nix build nixpkgs#nerd-fonts.jetbrains-mono`) and confirmed the `.ttf` files
  live under `share/fonts/truetype/NerdFonts/JetBrainsMono/`.

### Limits
This is an aarch64-darwin config, which cannot be built or activated on the
Linux agent, so **final `home-manager switch` verification must be done on the
Mac**. Everything above is eval/formatter/CI-gate/font-build verification only.

Run: 20260723-1912-3205ed29
