### PR TITLE
overlays: forward-pin claude-code to 2.1.219 (ahead of nixpkgs)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -87,6 +87,10 @@
           pkgs = import nixpkgs {
             inherit system;
             config.allowUnfree = true;
+            # Shared cosmo overlays (e.g. the temporary claude-code forward-pin).
+            # NixOS hosts get these via nixpkgs.overlays in
+            # modules/common/system.nix — keep both wiring points in sync.
+            overlays = import ./overlays;
           };
           extraSpecialArgs = { inherit inputs; };
           modules = [

--- a/modules/common/system.nix
+++ b/modules/common/system.nix
@@ -17,6 +17,13 @@
   };
 
   config = {
+    # Shared cosmo overlays (e.g. the temporary claude-code forward-pin).
+    # Hosts use home-manager.useGlobalPkgs = true, so home-manager inherits the
+    # system pkgs — applying the overlays here covers claude-code in every NixOS
+    # host's home config. The standalone homeConfigurations get the same overlays
+    # via mkHome's `import nixpkgs` in flake.nix; keep both wiring points in sync.
+    nixpkgs.overlays = import ../../overlays;
+
     # MemTest86+ boot entry for memory diagnostics (only on systemd-boot hosts)
     boot.loader.systemd-boot.memtest86 = lib.mkIf config.boot.loader.systemd-boot.enable {
       enable = true;

--- a/overlays/claude-code.nix
+++ b/overlays/claude-code.nix
@@ -1,0 +1,63 @@
+# TEMPORARY forward-pin of claude-code.
+#
+# cosmo installs claude-code from nixpkgs (see home/dev.nix). Upstream packages
+# it as a prebuilt per-platform binary (pkgs/by-name/cl/claude-code): a fetchurl
+# of the release binary from downloads.claude.ai, NOT a buildNpmPackage. There
+# is therefore no npmDepsHash — just a `version` plus a per-system `src`
+# (url + hash). Overriding a version means supplying the version and the matching
+# per-platform url + hash ourselves.
+#
+# As of this pin cosmo's locked nixpkgs ships claude-code 2.1.214 and
+# nixpkgs-unstable HEAD is only at 2.1.217, so `nix flake update` cannot reach
+# 2.1.219. We forward-pin to 2.1.219 here — the first release carrying the
+# claude-opus-5 model id.
+#
+# REMOVAL CONDITION: delete this overlay once nixpkgs provides
+# claude-code >= 2.1.219. The `versionAtLeast` guard below keeps nixpkgs' own
+# package whenever it is already at or beyond 2.1.219, so this override can never
+# silently DOWNGRADE claude-code once nixpkgs catches up to or surpasses it — but
+# the now-dead override should still be removed at that point.
+final: prev:
+let
+  version = "2.1.219";
+  baseUrl = "https://downloads.claude.ai/claude-code-releases";
+
+  # nixpkgs system -> claude release platform key + prefetched SRI hash of
+  # "${baseUrl}/${version}/${platform}/claude".
+  sources = {
+    x86_64-linux = {
+      platform = "linux-x64";
+      hash = "sha256-Is/W9bMGHAORuoTpz4yd6qN3g6rBiwBNQuwGHpjwBpE=";
+    };
+    aarch64-linux = {
+      platform = "linux-arm64";
+      hash = "sha256-H4NLMiup0Skcx//v8WpnlaWRRb2iedvVnNfs68e38Vo=";
+    };
+    aarch64-darwin = {
+      platform = "darwin-arm64";
+      hash = "sha256-qOgG+q76xTx6DyZSPYpFxg2+80B7FO+ZDHV2XQj+vII=";
+    };
+    x86_64-darwin = {
+      platform = "darwin-x64";
+      hash = "sha256-A76fmI7Yg5G0pfCOTF3DF84v/6Sp3GbAEQYybnaY7nY=";
+    };
+  };
+
+  inherit (prev.stdenv.hostPlatform) system;
+  entry = sources.${system} or (throw "claude-code forward-pin: unsupported system ${system}");
+in
+{
+  claude-code =
+    # Never downgrade: if nixpkgs is already at or ahead of the pin, keep its
+    # build untouched (see REMOVAL CONDITION above).
+    if prev.lib.versionAtLeast prev.claude-code.version version then
+      prev.claude-code
+    else
+      prev.claude-code.overrideAttrs (_: {
+        inherit version;
+        src = prev.fetchurl {
+          url = "${baseUrl}/${version}/${entry.platform}/claude";
+          inherit (entry) hash;
+        };
+      });
+}

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,0 +1,7 @@
+# Nixpkgs overlays applied everywhere cosmo builds packages: the standalone
+# homeConfigurations (via mkHome's `import nixpkgs`) and every NixOS host (via
+# `nixpkgs.overlays` in modules/common/system.nix). Keep both wiring points in
+# sync when adding an overlay here.
+[
+  (import ./claude-code.nix)
+]


### PR DESCRIPTION
## What

Add a temporary nixpkgs overlay pinning `claude-code` forward to **2.1.219**, bumping from the **2.1.214** in cosmo's locked nixpkgs (nixpkgs-unstable HEAD is only at **2.1.217**). 2.1.219 is the first release carrying the **claude-opus-5** model id.

## Why an overlay (not `nix flake update`)

nixpkgs packages `claude-code` as a **prebuilt per-platform binary** — a `fetchurl` of the release binary from `downloads.claude.ai`, **not** a `buildNpmPackage`. There is no `npmDepsHash`; the package is just a `version` plus a per-system `src` (`url` + `hash`). Since even nixpkgs-unstable HEAD is behind 2.1.219, `nix flake update` cannot reach it — a forward-pin override is required. The override supplies the version and the matching per-platform url + prefetched SRI hash for each system (`x86_64-linux`→`linux-x64`, `aarch64-linux`→`linux-arm64`, `aarch64-darwin`→`darwin-arm64`, `x86_64-darwin`→`darwin-x64`).

## Where it's applied

The overlay lives in `overlays/` (`overlays/default.nix` returns the list; `overlays/claude-code.nix` is the override) and is wired into **both** places cosmo builds packages:

- **Standalone `homeConfigurations`** — via `mkHome`'s `import nixpkgs { overlays = import ./overlays; }` in `flake.nix` (covers the `aarch64-darwin` Mac profile and the `x86_64-linux` profiles).
- **Every NixOS host** — via `nixpkgs.overlays` in `modules/common/system.nix` (imported by all hosts). Hosts use `home-manager.useGlobalPkgs = true`, so home-manager inherits the system `pkgs`.

## Temporary — removal condition

This is a **forward-pin ahead of nixpkgs**. A `lib.versionAtLeast` guard keeps nixpkgs' own package whenever it is already at or beyond 2.1.219, so the override **can never silently downgrade** `claude-code` once nixpkgs catches up or surpasses it. **Remove this overlay** once nixpkgs provides `claude-code >= 2.1.219`.

## Verification

- **x86_64-linux: built and ran** the overridden package — `result/bin/claude --version` reports **`2.1.219 (Claude Code)`** (the package's built-in `versionCheckHook` also gates this at build time).
- **Eval for every system**: the overridden `claude-code` evaluates to 2.1.219 with the correct per-platform URL for `x86_64-linux`, `aarch64-linux`, and `aarch64-darwin`. (`x86_64-darwin` is dropped by nixpkgs 26.11 upstream and cosmo has no such target; the map entry is documentary.)
- **Real wiring paths** confirmed to deliver 2.1.219: the Mac `homeConfiguration` (`aarch64-darwin`, darwin-arm64), a NixOS host (`classic-laddie`, linux-x64), and a standalone linux home config (linux-x64).
- **Full end-to-end eval**: `makers-nix` `system.build.toplevel` (NixOS module path) and the Mac `activationPackage` (darwin mkHome path) both evaluate to valid derivations.
- `nixfmt` and the cosmo pre-commit check (`nixfmt` / `detect-private-keys` / `zizmor`) pass; `klaus _pre-review` clean.

**Note:** the darwin build could not be *built* on this x86_64-linux agent (only evaluated, with the prefetched/verified darwin-arm64 hash). **Darwin activation should be confirmed on a Mac.**

Run: 20260724-1817-f1ccb509