### PR TITLE
feat(classic-laddie): replace Ollama with llama.cpp + llama-swap

### DIFF
--- a/hosts/classic-laddie/default.nix
+++ b/hosts/classic-laddie/default.nix
@@ -446,25 +446,65 @@ in
   };
 
   # ---------------------------------------------------------------------------
-  # Ollama (local LLM inference)
+  # Local LLM inference (llama.cpp + llama-swap)
   # ---------------------------------------------------------------------------
-  services.ollama = {
-    enable = true;
-    package = pkgs.ollama-cuda;
-    loadModels = [
-      "gemma4:26b"
-      "qwen3:32b"
-      "qwen2.5-coder:32b"
-    ];
-    environmentVariables = {
-      # Cap the default context so the 32B dense models (qwen3, qwen2.5-coder)
-      # stay fully resident in the 4090's 24GB VRAM. At Ollama's auto-selected
-      # 32K context the KV cache overflowed VRAM and spilled ~23% of the model
-      # to the CPU, badly hurting throughput. 8192 is a safe default for every
-      # model here; override per request with options.num_ctx when more is needed.
-      OLLAMA_CONTEXT_LENGTH = "8192";
+  # Replaces the previous services.ollama. Ollama vendors a custom ggml fork,
+  # and that fragility broke the nightly rebuild (ollama-cuda 0.32.1 failed to
+  # compile, wedging the whole classic-laddie generation), so inference moved
+  # to the upstream llama.cpp stack via the first-class nixpkgs modules.
+  #
+  # llama-swap fronts a single RTX 4090 (24GB): it loads exactly one model on
+  # request and unloads it after an idle TTL. A 32B Q4_K_M (~20GB) plus an
+  # 8192-token KV cache only fits one model at a time, so we swap rather than
+  # keep models co-resident.
+  #
+  # We use the CUDA-enabled llama.cpp *package* directly in each model's launch
+  # command rather than enabling a standalone services.llama-cpp: that would
+  # spawn a second, always-on llama-server holding a port (and potentially
+  # VRAM) for no benefit, defeating the load-on-request design. llama-swap owns
+  # the lifecycle of every llama-server process.
+  #
+  # llama-swap reuses ollama's old port (127.0.0.1:11434) and speaks the OpenAI
+  # API (/v1/chat/completions, /v1/models). Model IDs are kept identical to the
+  # old ollama tags so open-webui and other callers see the same names. GGUFs
+  # are pulled from Hugging Face at first use via llama-server's -hf flag into
+  # the service's persistent LLAMA_CACHE (/var/cache/llama-swap, a systemd
+  # CacheDirectory — outside the nix store and surviving restarts), so the first
+  # request for each model is a one-time slow download.
+  #
+  # The endpoint stays localhost-only (no openFirewall) — a deliberate security
+  # boundary matching the old ollama setup; open-webui is the only consumer.
+  services.llama-swap =
+    let
+      llama-cpp-cuda = pkgs.llama-cpp.override { cudaSupport = true; };
+      llama-server = lib.getExe' llama-cpp-cuda "llama-server";
+      # One model resident at a time: full GPU offload, 8192-token context
+      # (matching the old OLLAMA_CONTEXT_LENGTH so the KV cache fits in VRAM),
+      # bound to the port llama-swap assigns, HF GGUF pulled on demand, and
+      # idle-unloaded after 15 minutes to free VRAM for the next model.
+      mkModel = hfRepo: {
+        cmd = "${llama-server} --host 127.0.0.1 --port \${PORT} -ngl 99 -c 8192 -hf ${hfRepo} --no-webui";
+        ttl = 900;
+      };
+    in
+    {
+      enable = true;
+      listenAddress = "127.0.0.1";
+      port = 11434;
+      settings = {
+        # First-time model pulls (~18-20GB) can take a while; give the upstream
+        # server generous time to become healthy before llama-swap gives up.
+        healthCheckTimeout = 1800;
+        models = {
+          "qwen2.5-coder:32b" = mkModel "bartowski/Qwen2.5-Coder-32B-Instruct-GGUF:Q4_K_M";
+          "qwen3:32b" = mkModel "unsloth/Qwen3-32B-GGUF:Q4_K_M";
+          # 'gemma4:26b' has no clean upstream equivalent; the closest current
+          # Gemma at ~27B Q4_K_M is Gemma 3 27B IT. The llama-swap model ID is
+          # kept identical so callers see the same name.
+          "gemma4:26b" = mkModel "unsloth/gemma-3-27b-it-GGUF:Q4_K_M";
+        };
+      };
     };
-  };
 
   # ---------------------------------------------------------------------------
   # Open WebUI (LLM chat interface)
@@ -473,6 +513,13 @@ in
     enable = true;
     port = 8888;
     openFirewall = true;
+    environment = {
+      # Talk to the local llama-swap OpenAI-compatible endpoint instead of
+      # ollama's native API (which no longer exists on this host).
+      ENABLE_OLLAMA_API = "False";
+      OPENAI_API_BASE_URL = "http://127.0.0.1:11434/v1";
+      OPENAI_API_KEY = "sk-local";
+    };
   };
 
   age.secrets."github-token" = {

--- a/hosts/classic-laddie/default.nix
+++ b/hosts/classic-laddie/default.nix
@@ -448,40 +448,20 @@ in
   # ---------------------------------------------------------------------------
   # Local LLM inference (llama.cpp + llama-swap)
   # ---------------------------------------------------------------------------
-  # Replaces the previous services.ollama. Ollama vendors a custom ggml fork,
-  # and that fragility broke the nightly rebuild (ollama-cuda 0.32.1 failed to
-  # compile, wedging the whole classic-laddie generation), so inference moved
-  # to the upstream llama.cpp stack via the first-class nixpkgs modules.
-  #
-  # llama-swap fronts a single RTX 4090 (24GB): it loads exactly one model on
-  # request and unloads it after an idle TTL. A 32B Q4_K_M (~20GB) plus an
-  # 8192-token KV cache only fits one model at a time, so we swap rather than
-  # keep models co-resident.
-  #
-  # We use the CUDA-enabled llama.cpp *package* directly in each model's launch
-  # command rather than enabling a standalone services.llama-cpp: that would
-  # spawn a second, always-on llama-server holding a port (and potentially
-  # VRAM) for no benefit, defeating the load-on-request design. llama-swap owns
-  # the lifecycle of every llama-server process.
-  #
-  # llama-swap reuses ollama's old port (127.0.0.1:11434) and speaks the OpenAI
-  # API (/v1/chat/completions, /v1/models). Model IDs are kept identical to the
-  # old ollama tags so open-webui and other callers see the same names. GGUFs
-  # are pulled from Hugging Face at first use via llama-server's -hf flag into
-  # the service's persistent LLAMA_CACHE (/var/cache/llama-swap, a systemd
-  # CacheDirectory — outside the nix store and surviving restarts), so the first
-  # request for each model is a one-time slow download.
-  #
-  # The endpoint stays localhost-only (no openFirewall) — a deliberate security
-  # boundary matching the old ollama setup; open-webui is the only consumer.
+  # Replaces services.ollama, whose vendored ggml fork failed to compile
+  # (ollama-cuda 0.32.1) and wedged the nightly rebuild. llama-swap fronts one
+  # RTX 4090 (24GB): one model loaded per request, idle-unloaded (32B Q4_K_M +
+  # 8192 KV ~= 20GB -> no co-residency). CUDA llama.cpp invoked per-command, not
+  # a standalone services.llama-cpp (which would hold a second always-on
+  # server), so llama-swap owns each llama-server lifecycle. Reuses ollama's
+  # :11434, OpenAI API, identical model IDs; GGUFs pulled via -hf into
+  # LLAMA_CACHE. Localhost-only (no openFirewall); open-webui the sole consumer.
   services.llama-swap =
     let
       llama-cpp-cuda = pkgs.llama-cpp.override { cudaSupport = true; };
       llama-server = lib.getExe' llama-cpp-cuda "llama-server";
-      # One model resident at a time: full GPU offload, 8192-token context
-      # (matching the old OLLAMA_CONTEXT_LENGTH so the KV cache fits in VRAM),
-      # bound to the port llama-swap assigns, HF GGUF pulled on demand, and
-      # idle-unloaded after 15 minutes to free VRAM for the next model.
+      # Full GPU offload, 8192 ctx (KV fits VRAM), llama-swap-assigned $PORT, HF
+      # GGUF on demand, idle-unloaded after ttl (900s) to free VRAM.
       mkModel = hfRepo: {
         cmd = "${llama-server} --host 127.0.0.1 --port \${PORT} -ngl 99 -c 8192 -hf ${hfRepo} --no-webui";
         ttl = 900;
@@ -492,19 +472,24 @@ in
       listenAddress = "127.0.0.1";
       port = 11434;
       settings = {
-        # First-time model pulls (~18-20GB) can take a while; give the upstream
-        # server generous time to become healthy before llama-swap gives up.
+        # First pull (~20GB) is slow; wait before declaring unhealthy.
         healthCheckTimeout = 1800;
         models = {
           "qwen2.5-coder:32b" = mkModel "bartowski/Qwen2.5-Coder-32B-Instruct-GGUF:Q4_K_M";
           "qwen3:32b" = mkModel "unsloth/Qwen3-32B-GGUF:Q4_K_M";
-          # 'gemma4:26b' has no clean upstream equivalent; the closest current
-          # Gemma at ~27B Q4_K_M is Gemma 3 27B IT. The llama-swap model ID is
-          # kept identical so callers see the same name.
+          # No clean upstream 'gemma4:26b'; nearest ~27B Q4_K_M is Gemma 3 27B
+          # IT. ID kept identical so callers see the same name.
           "gemma4:26b" = mkModel "unsloth/gemma-3-27b-it-GGUF:Q4_K_M";
         };
       };
     };
+
+  # llama-server -hf writes ~20GB GGUFs to $LLAMA_CACHE, but the module runs
+  # DynamicUser with WorkingDirectory=/tmp, ProtectHome, and no writable state,
+  # so its default ~/.cache is read-only. Point it at a persistent
+  # CacheDirectory (auto-created, chowned to the dynamic user, survives reboot).
+  systemd.services.llama-swap.serviceConfig.CacheDirectory = "llama-swap";
+  systemd.services.llama-swap.environment.LLAMA_CACHE = "/var/cache/llama-swap";
 
   # ---------------------------------------------------------------------------
   # Open WebUI (LLM chat interface)


### PR DESCRIPTION
## Motivation

Ollama vendors a custom `ggml` fork, and that fragility broke the nightly rebuild: `ollama-cuda` 0.32.1 failed to compile, wedging the entire `classic-laddie` generation. This migrates local LLM inference off Ollama and onto the upstream **llama.cpp + llama-swap** stack using the first-class nixpkgs NixOS modules (`services.llama-swap`, plus the CUDA-enabled `llama-cpp` package).

## What changed

- Removed `services.ollama`.
- Added `services.llama-swap` on `127.0.0.1:11434` (reusing Ollama's port), serving the OpenAI API (`/v1/chat/completions`, `/v1/models`). It launches `llama-server` from a CUDA-enabled `pkgs.llama-cpp.override { cudaSupport = true; }`.
- Repointed `services.open-webui` (the only consumer) at the new endpoint:
  `ENABLE_OLLAMA_API=False`, `OPENAI_API_BASE_URL=http://127.0.0.1:11434/v1`, `OPENAI_API_KEY=sk-local`.

## Model mappings

Model IDs are kept **identical** to the old Ollama tags so open-webui and any callers see the same names. Each is pulled from a public HF GGUF repo at Q4_K_M:

| llama-swap ID | HF repo (`-hf`) |
|---|---|
| `qwen2.5-coder:32b` | `bartowski/Qwen2.5-Coder-32B-Instruct-GGUF:Q4_K_M` |
| `qwen3:32b` | `unsloth/Qwen3-32B-GGUF:Q4_K_M` |
| `gemma4:26b` | `unsloth/gemma-3-27b-it-GGUF:Q4_K_M` |

**Substitution note:** `gemma4:26b` has no clean upstream equivalent. The closest current Gemma at ~27B Q4_K_M is **Gemma 3 27B IT**, used here. The llama-swap model ID is left unchanged so callers are unaffected.

## Design notes

- **Single-model swap.** The 4090 has 24GB VRAM; a 32B Q4_K_M (~20GB) plus an 8192-token KV cache only fits one model at a time. llama-swap loads on request and unloads after a 15-minute idle TTL (`ttl = 900`), so VRAM frees when unused. No concurrent/co-resident models. Context kept at 8192 (matching the old `OLLAMA_CONTEXT_LENGTH`).
- **Runtime GGUF pull + persistent cache.** GGUFs are downloaded at first use via `llama-server -hf`. The `services.llama-swap` module runs `DynamicUser` with `WorkingDirectory=/tmp`, `ProtectHome`, and no writable state, so `llama-server`'s default `~/.cache` is read-only and `/tmp` is volatile — an un-set cache would fail on first model load or lose the download on reboot. This PR overrides the generated unit with `serviceConfig.CacheDirectory = "llama-swap"` (systemd auto-creates `/var/cache/llama-swap`, chowned to the dynamic user, surviving reboots) and sets `environment.LLAMA_CACHE = "/var/cache/llama-swap"` so downloads land there. **The first request for each model is a one-time slow download (~18–20GB);** `healthCheckTimeout = 1800` accommodates this.
- **Localhost-only.** The endpoint stays bound to `127.0.0.1` with no firewall opening — a deliberate security boundary matching the old Ollama setup.
- **No standalone `services.llama-cpp`.** The CUDA llama.cpp *package* is used directly in each model's launch command. Enabling the standalone `services.llama-cpp` would spawn a second always-on `llama-server` holding a port (and potentially VRAM) for no benefit, defeating the load-on-request design; llama-swap owns every `llama-server` process lifecycle. (This matches the llama-swap module's own usage example.)
- **No nixpkgs pin.** `flake.nix` stays on `nixos-unstable` with no temporary pin — with `ollama-cuda` gone, the frozen channel evaluates and resolves cleanly.

## Verification (in-session, synchronous)

- `nix flake check` — all checks passed.
- `nix eval` of `systemd.services.llama-swap.serviceConfig.CacheDirectory` (`llama-swap`) and `.environment` (`LLAMA_CACHE=/var/cache/llama-swap`), plus the rendered unit text, confirm the persistent cache override lands and merges with the module.
- `nix eval ...classic-laddie...toplevel.drvPath` — evaluates (module wiring valid).
- `nix build ...classic-laddie...toplevel --dry-run` — dependencies resolve; builds `llama-cpp` (CUDA), `config.yaml`, `unit-llama-swap.service`; no ollama.
- `--dry-run` for `makers-nix` and `johnny-walker` toplevels — no regression.
- Generated `config.yaml` inspected: `${PORT}` preserved, all three models present, correct `-ngl 99 -c 8192` and TTLs.

## Pending (coordinator, before merge)

The real **on-host CUDA build** and a **live model-load smoke test** (first-time HF pull + inference through open-webui) were intentionally **not** run in this session — they are long-running and are left to the coordinator on the host before merge.

Run: 20260725-0817-c6bd2f40

