### PR TITLE
chore: silence antigravity + pointerCursor eval warnings

### DIFF
--- a/home/desktop.nix
+++ b/home/desktop.nix
@@ -147,6 +147,7 @@
   '';
 
   home.pointerCursor = {
+    enable = true;
     gtk.enable = true;
     # x11.enable = true;
     package = pkgs.bibata-cursors;

--- a/home/dev.nix
+++ b/home/dev.nix
@@ -14,7 +14,7 @@
     default = false;
     description = ''
       Whether to install the native (non-FHS) Antigravity IDE
-      (pkgs.antigravity, autoPatchelf-based) and the antigravity CLI
+      (pkgs.antigravity-ide, autoPatchelf-based) and the antigravity CLI
       (pkgs.antigravity-cli). Unfree; requires
       nixpkgs.config.allowUnfree on the host.
     '';
@@ -104,7 +104,7 @@
         }))
       ]
       ++ lib.optionals config.cosmo.antigravity.enable [
-        pkgs.antigravity
+        pkgs.antigravity-ide
         pkgs.antigravity-cli
       ];
 


### PR DESCRIPTION
Two Nix evaluation warnings printed on every classic-laddie rebuild:

- `'antigravity' has been renamed to 'antigravity-ide'` — nixpkgs renamed the package. Renamed the single `pkgs.antigravity` reference in `home/dev.nix` (and its doc comment) to `pkgs.antigravity-ide`. `pkgs.antigravity-cli` is a separate package and left unchanged. The `cosmo.antigravity.enable` option namespace (repo-owned, unrelated to the warning) is untouched.
- `home.pointerCursor` deprecation — added explicit `enable = true;` to the `home.pointerCursor` block in `home/desktop.nix`.

Verified against the repo's pinned nixpkgs: `nix eval` of the classic-laddie toplevel emits neither warning, `pkgs.antigravity-ide` resolves (antigravity-ide-2.1.1), and `nix flake check` passes.

Run: 20260725-0852-c3439d27