### PR TITLE
feat(classic-laddie): upright NZXT Kraken LCD via liquidctl

### DIFF
--- a/hosts/classic-laddie/default.nix
+++ b/hosts/classic-laddie/default.nix
@@ -608,6 +608,43 @@ in
   security.sudo.wheelNeedsPassword = true;
 
   # ---------------------------------------------------------------------------
+  # NZXT Kraken Z-series LCD (USB 1e71:3008)
+  # ---------------------------------------------------------------------------
+  # Round LCD mounts rotated 180° in this case, so the liquid-temp readout is
+  # upside-down until re-oriented. Two parts:
+  #  1) liquidctl ships 71-liquidctl.rules (TAG+="uaccess" for 1e71:3008);
+  #     without it every liquidctl call fails "no langid" (no non-root access).
+  #  2) a root oneshot re-orients the panel. It's not a boot dependency — the
+  #     USB HID may enumerate late, so udev pulls it on device `add` (below),
+  #     firing on cold boot and on replug. initialize is required per plug
+  #     before set; the loop absorbs the settle window after enumeration.
+  services.udev.packages = [ pkgs.liquidctl ];
+  services.udev.extraRules = ''
+    ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="1e71", ATTR{idProduct}=="3008", TAG+="systemd", ENV{SYSTEMD_WANTS}+="kraken-lcd-orientation.service"
+  '';
+  systemd.services.kraken-lcd-orientation = {
+    description = "Set NZXT Kraken LCD to 180° (upright)";
+    serviceConfig = {
+      Type = "oneshot";
+      # Bounds the settle-retry loop; well under the udev-triggered budget.
+      TimeoutStartSec = 60;
+    };
+    path = [ pkgs.liquidctl ];
+    script = ''
+      # Pin the cooler so a future second liquidctl device can't ambiguate.
+      dev="--vendor 0x1e71 --product 0x3008"
+      for _ in $(seq 1 10); do
+        if liquidctl $dev initialize && liquidctl $dev set lcd screen orientation 180; then
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "kraken LCD unreachable after retries" >&2
+      exit 1
+    '';
+  };
+
+  # ---------------------------------------------------------------------------
   # PXE Boot Server (TFTP)
   # ---------------------------------------------------------------------------
   # Serves netboot.xyz for network installations


### PR DESCRIPTION
## What

classic-laddie's NZXT Kraken Z-series LCD (USB `1e71:3008`, liquidctl's `Kraken Z3` family) is mounted rotated 180° in the case, so its liquid-temp readout is upside-down. Separately, `liquidctl` had no packaged udev rules installed, so any non-root call failed with `The device has no langid` (permission issue).

This fixes both, scoped to the Kraken.

## Changes (`hosts/classic-laddie/default.nix`)

1. **udev access** — `services.udev.packages = [ pkgs.liquidctl ]`. liquidctl ships `71-liquidctl.rules`, which tags `1e71:3008` with `TAG+="uaccess"`, granting the device to the active seat/console user so liquidctl works without root.

2. **Orientation at boot** — a root `oneshot` `kraken-lcd-orientation.service` that re-orients the panel upright. It's not a boot-order dependency (the USB HID interface can enumerate late); instead a `services.udev.extraRules` entry pulls it in on device `add`, so it fires on cold boot and on replug:

   ```
   ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="1e71", ATTR{idProduct}=="3008", TAG+="systemd", ENV{SYSTEMD_WANTS}+="kraken-lcd-orientation.service"
   ```

   The service runs (device pinned via `--vendor 0x1e71 --product 0x3008`, with a 10× settle-retry loop):

   ```
   liquidctl --vendor 0x1e71 --product 0x3008 initialize
   liquidctl --vendor 0x1e71 --product 0x3008 set lcd screen orientation 180
   ```

   `initialize` is required per plug before `set`. Orientation syntax/values confirmed against liquidctl 1.16.0: usage `set <channel> screen <mode> [<value>]`, and the Kraken Z3 driver documents `lcd` `orientation` accepting `0`, `90`, `180`, `270` (°).

## Verification

- `nix build --dry-run .#nixosConfigurations.classic-laddie.config.system.build.toplevel` — evaluates (liquidctl pulled into the closure).
- `nix flake check` — all checks passed.
- `klaus _pre-review` — no issues.

The actual display flip can only be confirmed after this config is switched in (needs root on the host). **Orientation applies on the next `nixos-rebuild switch` (via the udev-triggered service on the next boot/replug); the maintainer confirms the flip visually.** No live `liquidctl` run was performed. The exact commands the service will run are pasted above.

Run: 20260725-0852-da5f395e
