### PR TITLE
feat(valley): add a git-only key class for scratch machines

### DIFF
--- a/docs/valley-git-hosting.md
+++ b/docs/valley-git-hosting.md
@@ -28,6 +28,24 @@ Access is host-level and key-only: the `git` user runs `git-shell`, every
 authorized key can reach every project. Repos live in `/srv/git` (moving to
 a dedicated `tank/git` ZFS dataset is a follow-up).
 
+### Who gets a key
+
+`services.valley.authorizedKeys` is `keys.users ++ keys.gitOnly`, two classes
+with deliberately different blast radius:
+
+- **`users`** — Patrick's own machines. These are also agenix recipients
+  (`secrets/secrets.nix` encrypts every secret to `users ++ hosts`) and shell
+  users (`modules/common/users.nix`). A key here can read every secret in the
+  repo.
+- **`gitOnly`** — scratch boxes and agent VMs that need to clone and push
+  projects and nothing else. Not agenix recipients, not shell users. Git
+  hosting is their entire reach.
+
+Add a machine that isn't yours to `gitOnly`. Because these keys are not
+recipients, adding or removing one needs no secret re-encryption: edit
+`keys.nix` and rebuild classic-laddie, and access changes with the
+activation.
+
 Every push is replicated best-effort to each mirror URL declared in
 `valley.cue` (`git push --mirror`, detached). A dead mirror only costs a
 journal line: `journalctl -t valley-mirror`.

--- a/hosts/classic-laddie/default.nix
+++ b/hosts/classic-laddie/default.nix
@@ -258,9 +258,16 @@ in
   services.valley = {
     enable = true;
     config = ./valley.cue;
-    # Host-level access by design: the same user keys that can decrypt
-    # secrets can push/fetch every project.
-    authorizedKeys = (import ../../secrets/keys.nix).users;
+    # Host-level access by design: every authorized key can push/fetch every
+    # project. Two classes of key get that access:
+    #   users    — the human keys, which can also decrypt secrets and log in.
+    #   gitOnly  — scratch and agent machines, which can do neither. Not
+    #              agenix recipients, not shell users: git hosting only.
+    authorizedKeys =
+      let
+        keys = import ../../secrets/keys.nix;
+      in
+      keys.users ++ keys.gitOnly;
     # Event bus (the-valley Phase 1): NATS JetStream feed of project ref
     # updates. Localhost only (127.0.0.1:4222, the module default) — widening
     # the listener is gated on bus authorization

--- a/secrets/keys.nix
+++ b/secrets/keys.nix
@@ -8,6 +8,16 @@ let
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICkzfSlbK9YX3KztdvtgfyJelixdI6QN3c41eme9HOWv" # weller
   ];
 
+  # Git-only keys. These reach valley git hosting and nothing else: they are
+  # deliberately NOT agenix recipients (see secrets.nix, which encrypts to
+  # `users ++ hosts`) and NOT shell users (see modules/common/users.nix).
+  # Add a key here when it belongs to a scratch or agent machine that should
+  # be able to clone and push projects without being able to decrypt any
+  # secret. Removing a key here revokes that access with no re-encryption.
+  gitOnly = [
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAvpmbUKEDVsejgv2vxWaY/t4xl0JNnjFswb9SxcG9GG" # stoned-flynn (exe.dev the-valley playground)
+  ];
+
   # Host Keys
   classic-laddie = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE7/mipW9wcQwVlDmEqBZksGDO3BEG94gb6VBuyDJUgk";
   weller = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGEqPYzGOvoeU3mpgBmw9XM/C3IaPETUBJeKtXsCBEBd";
@@ -17,6 +27,8 @@ let
 in
 {
   users = patrick;
+
+  inherit gitOnly;
 
   hosts = [
     classic-laddie


### PR DESCRIPTION
## What

Adds `keys.gitOnly`, a second class of SSH key wired **only** into
`services.valley.authorizedKeys` on classic-laddie.

## Why

`services.valley.authorizedKeys` was `keys.users`, which conflated two
unrelated questions:

- who may push to valley git hosting, and
- who may decrypt every secret in this repo.

`secrets/secrets.nix` encrypts every secret to `keys.users ++ keys.hosts`, so
the only way to let a scratch machine clone `the-valley` was to make it an
agenix recipient for the Anthropic key, the GitHub token, the VPN creds, and
everything else. That's a bad trade for a throwaway box.

## How

`gitOnly` keys reach git hosting and nothing else:

- not agenix recipients — `secrets.nix` still encrypts to `users ++ hosts`
- not shell users — `modules/common/users.nix`, `modules/bootstrap.nix`, and
  `modules/klaus-worker` still use `keys.users`
- the `git` user's shell is `git-shell`

Side benefit: because these keys are not recipients, adding or removing one
needs **no secret re-encryption**. Edit `keys.nix`, rebuild, done.

First member is the exe.dev VM being used as a the-valley playground.

## Verification

Beyond CI (`nixfmt --check` clean, `classic-laddie` toplevel evaluates):

```
$ nix eval ... # which users carry the new key?
playground key appears in users: git

$ nix eval ... c.users.users.git.shell
git shell: /nix/store/...-git-2.55.0/bin/git-shell

$ grep -rn gitOnly secrets/secrets.nix modules/
(no matches)
```

So the key lands in exactly one `authorized_keys` on the host — the `git`
user's — and in no secret or login path.

## Note on scope

valley access remains **host-level by design**: a `gitOnly` key can reach
every project on the host, including `qinling`, not just `the-valley`. That's
inherent to the current `valley-host` module, not something this PR changes.
Per-project ACLs would be a change in the-valley itself, and want a decision
node there rather than a workaround here.
