### PR TITLE
fix(media-server): services.overseerr -> services.seerr (upstream merge into Seerr)

### DIFF
--- a/modules/media-server/default.nix
+++ b/modules/media-server/default.nix
@@ -113,7 +113,9 @@ in
 
     # SABnzbd runs as a container below (routed through Gluetun for VPN)
 
-    services.overseerr = {
+    # Seerr (upstream merged Overseerr into Jellyseerr under this name). Port is
+    # still 5055, so the "overseerr" hostname/vhost below stay as-is (LAN DNS records).
+    services.seerr = {
       enable = true;
       openFirewall = true;
     };
@@ -172,7 +174,7 @@ in
     # 4. Reverse Proxy (Easy Access)
     # ---------------------------------------------------------
 
-    # Caddy reverse proxy for local media services (Jellyfin, Overseerr).
+    # Caddy reverse proxy for local media services (Jellyfin, Seerr).
     # default_bind restricts Caddy to the LAN interface (enp4s0, 192.168.1.28) and loopback
     # so it does not conflict with Tailscale Funnel, which needs :443 on the
     # Tailscale interface (100.111.60.17) for inbound webhooks.


### PR DESCRIPTION
## What broke

nixpkgs [#450096](https://github.com/NixOS/nixpkgs/pull/450096) (merged 2026-07-25) merged the Overseerr and Jellyseerr projects into one project, **Seerr** (Jellyseerr's codebase is the base). `services.overseerr` was removed via `mkRemovedOptionModule`, so it is a hard error, not a warning:

```
Failed assertions:
- The option definition `services.overseerr' in `.../modules/media-server/default.nix' no longer has any effect; please remove it.
```

`classic-laddie` is the only host importing `modules/media-server`, so it is the only failing `build-nixos` job; `check` fails for the same reason because `nix flake check` evaluates every host.

**This has blocked four nightly `flake.lock` updates** — #678 has been open since 07-28 and red on 07-28/29/30/31. Last lock to land was #677 on 07-27.

## The change

Rename the option block to `services.seerr`. Both `enable` and `openFirewall` exist on `services.seerr` with the same meaning (verified against `nixos/modules/services/misc/seerr.nix` in the pinned nixpkgs).

**No port changes.** Seerr's default port is still 5055, so the `overseerr` / `overseerr.local` Caddy vhosts, the `overseerr` entry in `networking.hosts`, and `overseerrUrl` in `hosts/classic-laddie/default.nix` (reel-life's own config option, not a nixpkgs option) are all still correct and left alone. Those vhost names are DNS labels matching a record on the LAN router.

## Data: existing config will be orphaned, not migrated

Read this before merging — it has a live consequence.

Seerr picks its state directory by `stateVersion`:

```nix
useNewConfigLocation = lib.versionAtLeast config.system.stateVersion "26.05";
StateDirectory = if useNewConfigLocation then "seerr" else "jellyseerr";
```

`classic-laddie` is on `25.11`, so seerr gets `StateDirectory = "jellyseerr"` → `/var/lib/jellyseerr/config`, **which does not exist on the host**.

The existing data lives at `/var/lib/overseerr` (the overseerr service is currently active). It will be **orphaned, not deleted** — so after this merge Seerr comes up as a **fresh install** (setup wizard, no users, no requests, no Plex/Sonarr/Radarr links) until a separate data migration is performed.

Pointing `services.seerr.configDir` at the old path does **not** work: `DynamicUser = true` derives the uid from the service name, so ownership of `/var/lib/overseerr` will not match.

No migration is attempted here, and deliberately no `preStart`/tmpfiles copy logic is added — the data migration is being handled separately as a root operation.

## Verification

Both previously-failing jobs now pass:

- `nix build .#nixosConfigurations.classic-laddie.config.system.build.toplevel --dry-run` — evaluates, emits `unit-seerr.service.drv`
- `nix flake check` — `all checks passed!` (all 7 host configurations)
- `makers-nix` and `johnny-walker` dry-run clean, no regression

No full build performed.

Run: 20260731-0720-0a099215