### PR TITLE
fix(classic-laddie): drop llama-swap cache overrides now that nixpkgs sets them

### DIFF
--- a/hosts/classic-laddie/default.nix
+++ b/hosts/classic-laddie/default.nix
@@ -491,13 +491,6 @@ in
       };
     };
 
-  # llama-server -hf writes ~20GB GGUFs to $LLAMA_CACHE, but the module runs
-  # DynamicUser with WorkingDirectory=/tmp, ProtectHome, and no writable state,
-  # so its default ~/.cache is read-only. Point it at a persistent
-  # CacheDirectory (auto-created, chowned to the dynamic user, survives reboot).
-  systemd.services.llama-swap.serviceConfig.CacheDirectory = "llama-swap";
-  systemd.services.llama-swap.environment.LLAMA_CACHE = "/var/cache/llama-swap";
-
   # ---------------------------------------------------------------------------
   # Open WebUI (LLM chat interface)
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
Deletes cosmo's two hand-patched llama-swap cache lines from
`hosts/classic-laddie/default.nix`:

```nix
systemd.services.llama-swap.serviceConfig.CacheDirectory = "llama-swap";
systemd.services.llama-swap.environment.LLAMA_CACHE = "/var/cache/llama-swap";
```

## The conflict

Under the bumped lock, evaluation fails:

```
error: The option `systemd.services.llama-swap.environment.LLAMA_CACHE' has conflicting definition values:
- nixpkgs .../llama-swap.nix: "/var/cache/llama-swap/huggingface/hub"
- cosmo hosts/classic-laddie/default.nix: "/var/cache/llama-swap"
```

## Why deleting is right

Cosmo added these on 2026-07-25 because the nixpkgs llama-swap module set
neither a `CacheDirectory` nor `LLAMA_CACHE`, leaving `llama-server -hf` with a
read-only default `~/.cache` under `DynamicUser`. Upstream has since implemented
both, with a better path:

```nix
environment = rec {
  XDG_CACHE_HOME = "/var/cache/${...CacheDirectory}";
  LLAMA_CACHE = "${XDG_CACHE_HOME}/huggingface/hub";
};
serviceConfig = { CacheDirectory = "llama-swap"; DynamicUser = true; };
```

So this removes a superseded workaround rather than losing a feature. Cosmo's
`CacheDirectory` line is now redundant (identical value); only the `LLAMA_CACHE`
line actually conflicts, and upstream's nested `huggingface/hub` path is the
more correct one.

No cached model data exists — llama-swap has never served a request, so nothing
has been downloaded into the old path. The path change is free; there is no
migration to do.

Under the *current* lock nothing sets these values after the deletion. That is
expected: the gap closes when the lock lands.

## Impact

Unblocks PR #678, stuck since 2026-07-28.

## Verification

- `nix build .#nixosConfigurations.classic-laddie.config.system.build.toplevel --dry-run` — passes
- `nix flake check` — all checks passed

Run: 20260731-1134-469527f4