### PR TITLE
feat(classic-laddie): add CUDA binary cache substituter

### DIFF
--- a/hosts/classic-laddie/default.nix
+++ b/hosts/classic-laddie/default.nix
@@ -463,6 +463,15 @@ in
   # server), so llama-swap owns each llama-server lifecycle. Reuses ollama's
   # :11434, OpenAI API, identical model IDs; GGUFs pulled via -hf into
   # LLAMA_CACHE. Localhost-only (no openFirewall); open-webui the sole consumer.
+  #
+  # cudaSupport overrides are unfree, so cache.nixos.org has no prebuilt paths
+  # (~20min of local nvcc per llama-cpp bump); this cache does. Appends to the
+  # defaults -- cache.nixos.org is still substituted.
+  nix.settings = {
+    substituters = [ "https://cache.nixos-cuda.org" ];
+    trusted-public-keys = [ "cache.nixos-cuda.org:74DUi4Ye579gUqzH4ziL9IyiJBlDpMRn9MBN8oNan9M=" ];
+  };
+
   services.llama-swap =
     let
       llama-cpp-cuda = pkgs.llama-cpp.override { cudaSupport = true; };


### PR DESCRIPTION
classic-laddie builds `llama-cpp` with `cudaSupport = true`. That override is unfree, so `cache.nixos.org` has no prebuilt paths for it and the host compiles CUDA from source — roughly 20 minutes of nvcc per llama-cpp bump (observed 2026-07-25). Before this change cosmo configured no substituters or trusted-public-keys anywhere.

## Evidence

narinfo probes for `/nix/store/p57dc4wgfy99zl837snsl30s8rb13df4-llama-cpp-10063`:

| cache | result |
|---|---|
| `https://cache.nixos-cuda.org` | **HTTP 200** — has it |
| `https://cuda-maintainers.cachix.org` | HTTP 404 — legacy host, still answers but lacks the paths |
| `https://cache.nixos.org` | HTTP 404 — expected |

Hence `cache.nixos-cuda.org`, not the old cachix address.

## Scope

classic-laddie only — it is the sole CUDA host, so this stays out of `modules/common/system.nix` and is not fleet-wide.

## Defaults preserved

Both `substituters` and `trusted-public-keys` are list options whose nixpkgs defaults are real definitions, so a host-level definition concatenates rather than replaces. Verified:

```
$ nix eval .#nixosConfigurations.classic-laddie.config.nix.settings.substituters
[ "https://cache.nixos-cuda.org" "https://cache.nixos.org/" ]

$ nix eval .#nixosConfigurations.classic-laddie.config.nix.settings.trusted-public-keys
[ "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=" "cache.nixos-cuda.org:74DUi4Ye579gUqzH4ziL9IyiJBlDpMRn9MBN8oNan9M=" ]
```

The official cache and its key are both still present alongside the new entries.

## Checks

- `nix flake check` — all checks passed
- `nix build .#nixosConfigurations.classic-laddie.config.system.build.toplevel --dry-run` — evaluates clean (14 derivations, no build attempted)

The dry-run still lists `llama-cpp` as to-be-built because it ran here, without the new `nix.conf` active; the substituter takes effect on classic-laddie once this is deployed.

Run: 20260731-1159-c5067804