### PR TITLE
overlays: fix hyprland build against glaze 8.0.0

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -4,4 +4,5 @@
 # sync when adding an overlay here.
 [
   (import ./claude-code.nix)
+  (import ./hyprland-glaze.nix)
 ]

--- a/overlays/hyprland-glaze.nix
+++ b/overlays/hyprland-glaze.nix
@@ -1,0 +1,31 @@
+# TEMPORARY build fix for hyprland.
+#
+# The locked nixpkgs (nixos-unstable e72e4f2) bumped glaze 7.9.1 -> 8.0.0
+# without the companion hyprland fix, so hyprland's
+# `find_package(glaze 7...<8)` misses and CMake falls back to a network
+# FetchContent that cannot work in the sandbox ("could not find git for clone
+# of glaze", nixpkgs issue #549246). Upstream fixed this on master in commit
+# e0832b87 ("hyprland: fix build by relaxing glaze dependency") by relaxing
+# the version range in postPatch; this overlay replicates that exact change.
+#
+# REMOVAL CONDITION: delete this overlay once the locked nixpkgs contains
+# e0832b87. Verify with
+#   git -C <nixpkgs> merge-base --is-ancestor e0832b87 <locked rev>
+# or simply: nixpkgs' hyprland postPatch already mentions glaze. The guard
+# below keeps nixpkgs' own package untouched in that case, so a stale overlay
+# cannot re-break the build — but remove the dead code anyway.
+final: prev: {
+  hyprland =
+    # No-op once nixpkgs' own postPatch handles glaze (see REMOVAL CONDITION).
+    if prev.lib.hasInfix "glaze" (prev.hyprland.postPatch or "") then
+      prev.hyprland
+    else
+      prev.hyprland.overrideAttrs (old: {
+        postPatch = ''
+          # Relax glaze dependency (nixpkgs e0832b87)
+          substituteInPlace CMakeLists.txt start/CMakeLists.txt hyprpm/CMakeLists.txt \
+            --replace-fail "glaze 7...<8" "glaze"
+        ''
+        + (old.postPatch or "");
+      });
+}


### PR DESCRIPTION
## Problem

classic-laddie's converge loop (cosmo-rebuild) has been failing since ~07:04 on 2026-08-05: the toplevel build dies under hyprland with `could not find git for clone of glaze`, cascading through xdg-desktop-portal-hyprland.

The locked nixpkgs (nixos-unstable `e72e4f2`, unchanged through #706/#707) bumped glaze 7.9.1 → 8.0.0 without the companion hyprland fix. hyprland's `find_package(glaze 7...<8)` no longer matches, and CMake falls back to a network FetchContent that cannot work in the build sandbox (nixpkgs issue #549246).

## Fix

Upstream fixed this on nixpkgs master in `e0832b87` ("hyprland: fix build by relaxing glaze dependency") — a `postPatch` addition relaxing the CMake version range `glaze 7...<8` to `glaze`. That commit hasn't reached nixos-unstable, and a lock revert would be undone by tonight's auto-merged daily bump, so this PR carries the exact upstream change as a temporary overlay (`overlays/hyprland-glaze.nix`), wired through `overlays/default.nix` like the existing claude-code pin. Both sides ship the same hyprland 0.56.1 source, so the substitution applies verbatim.

## Retirement

Delete the overlay once the locked nixpkgs contains `e0832b87` (verify: `git merge-base --is-ancestor e0832b87 <locked rev>`, or nixpkgs' own hyprland `postPatch` mentions glaze). Until then it is safe to leave in place: a `hasInfix "glaze"` guard on the upstream `postPatch` makes the overlay a no-op once the channel carries the fix, so it cannot re-break the build the way the catppuccin overlay did (#636).

## Verification

- `nix eval` confirms the override reaches `nixosConfigurations.classic-laddie.pkgs.hyprland.postPatch`.
- `klaus _pre-review`: no findings.
- Local toplevel build verification in progress (`nix build .#nixosConfigurations.classic-laddie.config.system.build.toplevel --no-link` — the exact invocation the converge unit runs); result will be confirmed in a comment.

Run: 20260806-0242-8a4c091f