### PR TITLE
klaus: pin fleet-default agent model to opus

### DIFF
--- a/home/dev.nix
+++ b/home/dev.nix
@@ -137,6 +137,7 @@
         default_branch = "main";
         trusted_reviewers = [ "gemini-code-assist[bot]" ];
         auto_merge_on_approval = true;
+        default_agent_model = "opus";
         webhook = {
           port = 9800;
           path = "/webhook/github";


### PR DESCRIPTION
klaus launch now supports --model/--effort with config defaults; until the config pins default_agent_model, every dispatched agent silently inherits the operator's interactive model preference. Pinning "opus" decouples fleet policy from interactive preference; per-dispatch flags tier up or down from it.

default_agent_effort is intentionally left unset — claude's own default applies.

Verification in progress: running `nix build .#nixosConfigurations.classic-laddie.config.system.build.toplevel --no-link` to confirm the home-manager rebuild succeeds; will comment with the result.

Run: 20260806-0406-9b67f813