### PR TITLE
Configure jujutsu identity to match git

### DIFF
--- a/home/dev.nix
+++ b/home/dev.nix
@@ -86,7 +86,6 @@
 
         # CLIs
         github-cli # GitHub CLI (gh)
-        jujutsu # Modern VCS (jj)
         difftastic # Structural diff (difft), wired to the `git dft` alias below
 
         # Age tools
@@ -126,6 +125,9 @@
     # Structural second-opinion diff: `git dft` runs difftastic on demand
     # without making it the default differ.
     programs.git.settings.alias.dft = "-c diff.external=difft diff";
+
+    # Modern VCS (jj); user identity is set per-identity (see home/identities/*.nix).
+    programs.jujutsu.enable = true;
 
     # Klaus agent orchestration config
     home.file.".klaus/config.json" = lib.mkIf config.cosmo.klaus.enable {

--- a/home/identities/personal.nix
+++ b/home/identities/personal.nix
@@ -1,11 +1,11 @@
 { ... }:
-{
-  programs.git = {
-    settings = {
-      user = {
-        name = "Patrick Flynn";
-        email = "big.pat@gmail.com";
-      };
-    };
+let
+  user = {
+    name = "Patrick Flynn";
+    email = "big.pat@gmail.com";
   };
+in
+{
+  programs.git.settings.user = user;
+  programs.jujutsu.settings.user = user;
 }

--- a/home/identities/work.nix
+++ b/home/identities/work.nix
@@ -1,4 +1,10 @@
 { lib, ... }:
+let
+  workUser = {
+    name = "Patrick Flynn";
+    email = "paflynn@google.com";
+  };
+in
 {
   # Corp hosts (bushmills, work crostini) can't reach the Tailscale webhook
   # relay, so klaus must poll GitHub for pipeline events instead.
@@ -16,12 +22,6 @@
     fi
   '';
 
-  programs.git = {
-    settings = {
-      user = {
-        name = "Patrick Flynn";
-        email = "paflynn@google.com";
-      };
-    };
-  };
+  programs.git.settings.user = workUser;
+  programs.jujutsu.settings.user = workUser;
 }


### PR DESCRIPTION
## Summary
- programs.jujutsu is now enabled as a proper home-manager program (was a bare `home.packages` entry in dev.nix)
- Each identity file (personal.nix, work.nix) shares one name/email binding between programs.git.settings.user and programs.jujutsu.settings.user

## Test plan
- [ ] `nix build .#nixosConfigurations.classic-laddie.config.system.build.toplevel --no-link` — verification in progress

Run: 20260807-1024-e51b6f29